### PR TITLE
fix: preserve source order on equal-score ties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented here.
 - Apply one reusable Herdr Plus tabs/panes template to any zoxide/root directory with a configurable shortcut (`Alt-Enter` by default), creating the workspace or appending fresh template tabs when already open; `Enter` keeps normal behavior.
 - Press `F5` on the update badge to confirm and install the available release through Herdr.
 
+### Fixed
+- Equal-score results now keep their source order (zoxide frecency, agent pane order) instead of sorting alphabetically.
+
 ## [0.3.3] - 2026-07-18
 
 ### Fixed

--- a/src/app.rs
+++ b/src/app.rs
@@ -175,13 +175,7 @@ impl App {
                         .source_rank(&self.entries[*idx_a].source)
                         .cmp(&self.config.picker.source_rank(&self.entries[*idx_b].source))
                 })
-                .then_with(|| {
-                    if agent_view {
-                        idx_a.cmp(idx_b)
-                    } else {
-                        self.entries[*idx_a].title.cmp(&self.entries[*idx_b].title)
-                    }
-                })
+                .then_with(|| idx_a.cmp(idx_b))
         });
         let (scores, filtered): (Vec<_>, Vec<_>) = scored.into_iter().unzip();
         self.filtered = filtered;
@@ -935,6 +929,19 @@ mod tests {
             app.selected_entry().unwrap().workspace_id.as_deref(),
             Some("w1")
         );
+    }
+
+    #[test]
+    fn equal_score_ties_preserve_insertion_order() {
+        let mut app = App::new(Config::default(), Theme::load(false));
+        app.entries = vec![
+            entry(Source::Zoxide, "/zulu", "zulu"),
+            entry(Source::Zoxide, "/alpha", "alpha"),
+        ];
+
+        app.apply_filter();
+
+        assert_eq!(app.selected_entry().unwrap().title, "zulu");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Equal-score results are tie-broken alphabetically by title, which throws away the collectors' meaningful order — `zoxide query -l` is frecency-ordered, agents arrive in pane order. Example: querying a project name over several sibling paths under the same directory gives them all the same score, and the most-visited root dir ends up buried below its subdirectories.

This makes the tie-break preserve insertion order (`idx.cmp`), as the agent view already did — the special case collapses into the general one. Includes a regression test that fails on `main`.

Note: two pre-existing `cargo test` failures on macOS (unrelated — fixtures use literal `/tmp`, which `Entry::key()` canonicalizes to `/private/tmp`); happy to file a follow-up.

## Checks

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (except the pre-existing macOS failures above)
- [x] `cargo build --release`