### PR TITLE
fix(theme): match Herdr default palette

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -412,16 +412,17 @@ impl Theme {
         }
         let path = herdr_config_path();
         let Ok(s) = fs::read_to_string(path) else {
-            return Self::one_light();
+            return Self::catppuccin();
         };
         let Ok(v) = s.parse::<toml::Value>() else {
-            return Self::one_light();
+            return Self::catppuccin();
         };
         Self::from_herdr_config(&v)
     }
 
     fn from_herdr_config(v: &toml::Value) -> Self {
-        let mut theme = Self::one_light();
+        // Match Herdr's own fallback when [theme].name is absent or unknown.
+        let mut theme = Self::catppuccin();
         if let Some(name) = v
             .get("theme")
             .and_then(|x| x.as_table())
@@ -560,6 +561,27 @@ mod tests {
 
     fn theme_value(toml_src: &str) -> toml::Value {
         toml_src.parse::<toml::Value>().expect("valid toml")
+    }
+
+    #[test]
+    fn inherits_herdr_default_when_theme_is_not_configured() {
+        let theme = Theme::from_herdr_config(&theme_value(""));
+
+        assert_eq!(theme.panel_bg, rgb(24, 24, 37));
+        assert_eq!(theme.accent, rgb(137, 180, 250));
+    }
+
+    #[test]
+    fn unknown_theme_falls_back_to_herdr_default() {
+        let theme = Theme::from_herdr_config(&theme_value(
+            r#"
+            [theme]
+            name = "future-theme"
+            "#,
+        ));
+
+        assert_eq!(theme.panel_bg, rgb(24, 24, 37));
+        assert_eq!(theme.accent, rgb(137, 180, 250));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- use Catppuccin as the inherited fallback when Herdr has no explicit `[theme].name`
- keep One Light as Navigator's standalone palette when `inherit_herdr = false`
- cover missing and unknown theme names with regression tests

Fixes #5.

## Checks

- [ ] `cargo fmt --check` — unavailable locally because the stable toolchain does not include `rustfmt`
- [ ] `cargo clippy -- -D warnings` — blocked by pre-existing `clippy::items_after_test_module` in `src/main.rs`
- [ ] `cargo test` — 67 passed, 2 pre-existing app tests failed (`close_target_matches_entry_kind`, `source_specific_reuse_distinguishes_same_path_workspaces`)
- [x] `cargo test theme::tests::` — 5 passed
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)