### PR TITLE
fix(agents): focus by pane id instead of terminal id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented here.
 - Apply one reusable Herdr Plus tabs/panes template to any zoxide/root directory with a configurable shortcut (`Alt-Enter` by default), creating the workspace or appending fresh template tabs when already open; `Enter` keeps normal behavior.
 - Press `F5` on the update badge to confirm and install the available release through Herdr.
 
+### Fixed
+- Focus an agent from the picker again. Every agent entry targeted its terminal id, which Herdr rejects with `agent_not_found`; entries now target the pane id. Terminal ids stay searchable.
+
 ## [0.3.3] - 2026-07-18
 
 ### Fixed

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -143,6 +143,10 @@ fn agents_from_json(
                 .get("terminal_id")
                 .and_then(|v| v.as_str())
                 .unwrap_or(pane);
+            // `herdr agent <target>` resolves unique agent names and pane ids only — a
+            // terminal id is rejected with agent_not_found, so it stays searchable but
+            // never becomes the focus target.
+            let target = if pane.is_empty() { term } else { pane };
             let cwd = p.get("cwd").and_then(|v| v.as_str()).unwrap_or("/");
             let foreground_cwd = p
                 .get("foreground_cwd")
@@ -189,10 +193,10 @@ fn agents_from_json(
                 path,
                 workspace_id: (!workspace_id.is_empty()).then(|| workspace_id.into()),
                 workspace_label: Some(workspace_label.into()),
-                agent_target: Some(term.into()),
+                agent_target: Some(target.into()),
                 project: None,
                 action: EntryAction::FocusAgent {
-                    target: term.into(),
+                    target: target.into(),
                 },
                 source_label: None,
                 search_terms,
@@ -333,7 +337,14 @@ mod tests {
              "revision":0,"tab_id":"w43:t1","terminal_id":"term_1","workspace_id":"w43"}]}});
         let agents = agents_from_json(&agent_json, &entries, &[]);
         assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].agent_target.as_deref(), Some("term_1"));
+        // Focus must target the pane id: `herdr agent focus term_1` fails with agent_not_found.
+        assert_eq!(agents[0].agent_target.as_deref(), Some("w43:p1"));
+        assert!(matches!(
+            &agents[0].action,
+            EntryAction::FocusAgent { target } if target == "w43:p1"
+        ));
+        // The terminal id is still typeable in the picker, just not the focus target.
+        assert!(agents[0].search_terms.contains(&"term_1".to_string()));
         assert!(agents[0].search_terms.contains(&"58f4-session".to_string()));
         assert!(agents[0].subtitle.starts_with("working"));
     }


### PR DESCRIPTION
## Summary

Focusing an agent from the picker always fails. Agent entries carry `terminal_id` as their focus target, but `herdr agent <target>` resolves unique agent names and pane ids only — so every `Enter` on an agent row returns `agent_not_found` and the plugin exits `1`.

The same agent, addressed two ways against a live session:

```console
$ herdr agent get w1:p7
{"id":"cli:agent:get","result":{"agent":{"agent":"claude",…,"pane_id":"w1:p7","terminal_id":"term_657660f21a5c19",…}}}

$ herdr agent get term_657660f21a5c19
{"error":{"code":"agent_not_found","message":"agent target term_657660f21a5c19 not found"},"id":"cli:agent:get"}
```

`agents_from_json` now targets `pane_id`, keeping the terminal id as a fallback for records that have no pane. Terminal ids stay in `search_terms`, so the README's "search … pane/tab/terminal IDs" still holds — only the focus target changed.

Verified against Herdr 0.7.5 on macOS: `herdr agent focus <pane_id>` succeeds for every agent in `herdr agent list`, while every `terminal_id` is rejected.

## Checks

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`

One note on `cargo test`: `app::tests::close_target_matches_entry_kind` and `app::tests::source_specific_reuse_distinguishes_same_path_workspaces` fail here, but they fail identically on a clean clone of `main` — this branch doesn't touch them. They look macOS-specific: `Entry::key()` canonicalizes, and macOS resolves the fixtures' `/tmp` to `/private/tmp`, so the `path_to_workspaces` lookups miss. Left alone as out of scope; happy to open a separate issue or PR if useful.
