### PR TITLE
fix(theme): honor plugin theme config

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Useful config surfaces:
 - `[picker.filter_keys]` remaps source shortcuts.
 - `[[agent_aliases]]` adds memorable search terms without renaming Herdr panes.
 - `[sessions]` controls local sessions and manual remote targets.
-- `[theme]` inherits supported Herdr themes and custom tokens.
+- `[theme]` sets the palette via `name`, inherits the Herdr theme when `inherit_herdr` is set, and layers `[theme.custom]` color tokens over the base (overriding any inherited from the main Herdr config).
 - `[[integrations]]` adds external command/JSON sources.
 
 ## Add your own source

--- a/examples/default-config.toml
+++ b/examples/default-config.toml
@@ -106,9 +106,15 @@ sessions = true
 herdr_plus_quick_actions = true
 
 [theme]
-# Reads ~/.config/herdr/config.toml theme name and [theme.custom] tokens when available.
-# Falls back to the built-in One Light palette.
+# Theme name. Takes precedence over inherit_herdr. If unset and inherit_herdr
+# is true, use the theme from Herdr's main config. Otherwise use One Light.
+# name = "dracula"
 inherit_herdr = true
+
+# Same [theme.custom] tokens as Herdr's main config. Applied on top of the
+# theme above, after any [theme.custom] inherited from Herdr's main config.
+# [theme.custom]
+# accent = "#ff00ff"
 
 # Keep roots short; zoxide should handle most frequent directories.
 [[roots]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -891,7 +891,7 @@ mod tests {
 
     #[test]
     fn default_empty_picker_prioritizes_agent_status() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.config.picker.agent_sort = "priority".into();
         app.entries = vec![
             agent_entry_with_status("idle"),
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn previous_workspace_is_pinned_only_on_initial_unfiltered_view() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut alpha = entry(Source::Workspace, "/alpha", "alpha");
         alpha.workspace_id = Some("w1".into());
         alpha.action = EntryAction::FocusWorkspace { id: "w1".into() };
@@ -939,7 +939,7 @@ mod tests {
 
     #[test]
     fn pinned_entries_sort_first_and_persist() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.entries = vec![
             entry(Source::Root, "/alpha", "alpha"),
             entry(Source::Root, "/zulu", "zulu"),
@@ -962,7 +962,7 @@ mod tests {
 
     #[test]
     fn previous_workspace_sorts_before_marked_entries() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let marked = entry(Source::Root, "/marked", "marked");
         let mut previous = entry(Source::Workspace, "/previous", "previous");
         previous.workspace_id = Some("w2".into());
@@ -981,9 +981,9 @@ mod tests {
 
     #[test]
     fn source_specific_reuse_distinguishes_same_path_workspaces() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.path_to_workspaces.insert(
-            "/tmp".into(),
+            entry(Source::Zoxide, "/tmp", "tmp").key(),
             vec![
                 workspace("w1", "project: tmp", WorkspaceKind::Project, "/tmp"),
                 workspace("w2", "dir: tmp", WorkspaceKind::Dir, "/tmp"),
@@ -1007,7 +1007,7 @@ mod tests {
     fn offers_directory_template_for_new_and_existing_directory_workspaces() {
         let mut config = Config::default();
         config.picker.directory_template = Some("default.toml".into());
-        let mut app = App::new(config, Theme::load(false));
+        let mut app = App::new(config, Theme::load(None, None, false));
         app.entries = vec![entry(Source::Zoxide, "/tmp", "tmp")];
         app.apply_filter();
 
@@ -1039,9 +1039,9 @@ mod tests {
 
     #[test]
     fn close_target_matches_entry_kind() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.path_to_workspaces.insert(
-            "/tmp".into(),
+            entry(Source::Root, "/tmp", "tmp").key(),
             vec![
                 workspace("w1", "project: tmp", WorkspaceKind::Project, "/tmp"),
                 workspace("w2", "dir: tmp", WorkspaceKind::Dir, "/tmp"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,10 @@ pub(crate) struct IntegrationConfig {
 
 #[derive(Clone, Deserialize)]
 pub(crate) struct ThemeConfig {
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+    #[serde(default)]
+    pub(crate) custom: HashMap<String, String>,
     #[serde(default = "yes")]
     pub(crate) inherit_herdr: bool,
 }
@@ -349,6 +353,8 @@ impl Default for NotificationsConfig {
 impl Default for ThemeConfig {
     fn default() -> Self {
         Self {
+            name: None,
+            custom: HashMap::new(),
             inherit_herdr: true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,11 @@ fn jump_back() -> ! {
 fn run_ui(persist: bool) -> ! {
     let config = Config::load();
     let check_updates = config.picker.check_updates;
-    let theme = Theme::load(config.theme.inherit_herdr);
+    let theme = Theme::load(
+        config.theme.name.as_deref(),
+        Some(&config.theme.custom),
+        config.theme.inherit_herdr,
+    );
     let mut app = App::new(config, theme);
     app.refresh();
     let update_check = check_updates.then(update::check_in_background);
@@ -253,7 +257,7 @@ mod tests {
 }
 
 fn debug_list() {
-    let mut app = App::new(Config::load(), Theme::load(true));
+    let mut app = App::new(Config::load(), Theme::load(None, None, true));
     app.refresh();
     for e in app.entries {
         println!("{}\t{}\t{}", e.source_name(), e.title, e.path.display());

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
 };
@@ -406,37 +407,35 @@ impl Theme {
         }
     }
 
-    pub(crate) fn load(inherit: bool) -> Self {
-        if !inherit {
-            return Self::one_light();
+    pub(crate) fn load(
+        name: Option<&str>,
+        custom: Option<&HashMap<String, String>>,
+        inherit: bool,
+    ) -> Self {
+        let herdr = inherit.then(read_herdr_config).flatten();
+
+        let herdr_name = herdr.as_ref().and_then(herdr_theme_name);
+        let mut theme = name
+            .or(herdr_name.as_deref())
+            .and_then(Self::from_name)
+            .unwrap_or_else(Self::one_light);
+
+        if let Some(herdr_custom) = herdr.as_ref().and_then(herdr_theme_custom) {
+            theme.apply_custom(herdr_custom);
         }
-        let path = herdr_config_path();
-        let Ok(s) = fs::read_to_string(path) else {
-            return Self::one_light();
-        };
-        let Ok(v) = s.parse::<toml::Value>() else {
-            return Self::one_light();
-        };
-        Self::from_herdr_config(&v)
+        if let Some(custom) = custom {
+            theme.apply_custom_map(custom);
+        }
+        theme
     }
 
+    #[cfg(test)]
     fn from_herdr_config(v: &toml::Value) -> Self {
-        let mut theme = Self::one_light();
-        if let Some(name) = v
-            .get("theme")
-            .and_then(|x| x.as_table())
-            .and_then(|x| x.get("name"))
-            .and_then(|x| x.as_str())
+        let mut theme = herdr_theme_name(v)
+            .as_deref()
             .and_then(Self::from_name)
-        {
-            theme = name;
-        }
-        if let Some(custom) = v
-            .get("theme")
-            .and_then(|x| x.as_table())
-            .and_then(|x| x.get("custom"))
-            .and_then(|x| x.as_table())
-        {
+            .unwrap_or_else(Self::one_light);
+        if let Some(custom) = herdr_theme_custom(v) {
             theme.apply_custom(custom);
         }
         theme
@@ -474,6 +473,14 @@ impl Theme {
         }
     }
 
+    fn apply_custom_map(&mut self, custom: &HashMap<String, String>) {
+        for (k, v) in custom {
+            if let Some(c) = parse_color(v) {
+                self.set(k, c);
+            }
+        }
+    }
+
     fn set(&mut self, key: &str, color: Color) {
         match key {
             "accent" => self.accent = color,
@@ -502,6 +509,27 @@ fn herdr_config_path() -> PathBuf {
         return Path::new(&xdg).join("herdr/config.toml");
     }
     home().join(".config/herdr/config.toml")
+}
+
+fn read_herdr_config() -> Option<toml::Value> {
+    fs::read_to_string(herdr_config_path())
+        .ok()
+        .and_then(|s| s.parse::<toml::Value>().ok())
+}
+
+fn herdr_theme_name(v: &toml::Value) -> Option<String> {
+    v.get("theme")
+        .and_then(|x| x.as_table())
+        .and_then(|x| x.get("name"))
+        .and_then(|x| x.as_str())
+        .map(str::to_owned)
+}
+
+fn herdr_theme_custom(v: &toml::Value) -> Option<&toml::map::Map<String, toml::Value>> {
+    v.get("theme")
+        .and_then(|x| x.as_table())
+        .and_then(|x| x.get("custom"))
+        .and_then(|x| x.as_table())
 }
 
 fn normalize_theme_name(name: &str) -> String {
@@ -636,5 +664,19 @@ mod tests {
         assert_eq!(theme.accent, rgb(1, 2, 3));
         assert_eq!(theme.green, Color::Blue);
         assert_eq!(theme.peach, Color::Reset);
+    }
+
+    #[test]
+    fn plugin_custom_map_overrides_base_palette() {
+        let mut theme = Theme::dracula();
+        let custom = HashMap::from([
+            ("accent".to_string(), "#ff00ff".to_string()),
+            ("panel_bg".to_string(), "reset".to_string()),
+        ]);
+        theme.apply_custom_map(&custom);
+
+        assert_eq!(theme.accent, rgb(255, 0, 255));
+        assert_eq!(theme.panel_bg, Color::Reset);
+        assert_eq!(theme.text, rgb(248, 248, 242));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -916,7 +916,7 @@ mod tests {
 
     #[test]
     fn herdr_plus_sources_share_color() {
-        let theme = Theme::load(false);
+        let theme = Theme::load(None, None, false);
         assert_eq!(
             source_color(&theme, &Source::Project),
             source_color(&theme, &Source::QuickAction)
@@ -927,7 +927,7 @@ mod tests {
     fn alt_enter_opens_selected_directory_with_configured_template() {
         let mut config = Config::default();
         config.picker.directory_template = Some("default.toml".into());
-        let mut app = App::new(config, Theme::load(false));
+        let mut app = App::new(config, Theme::load(None, None, false));
         app.entries = vec![entry(Source::Zoxide, "/tmp")];
         app.apply_filter();
 
@@ -952,7 +952,7 @@ mod tests {
 
     #[test]
     fn update_badge_renders_action_and_f5_triggers_it() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         assert!(matches!(
             handle_key(
                 &mut app,
@@ -978,7 +978,7 @@ mod tests {
 
     #[test]
     fn status_colors_match_herdr() {
-        let theme = Theme::load(false);
+        let theme = Theme::load(None, None, false);
 
         assert_eq!(agent_status_color(&theme, "blocked"), theme.red);
         assert_eq!(agent_status_color(&theme, "working"), theme.yellow);
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn open_and_pinned_workspaces_replace_tree_branches_with_diamonds() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut current = entry(Source::Workspace, "Current");
         current.workspace_id = Some("w1".into());
         current.search_terms.push("focused".into());
@@ -1022,7 +1022,7 @@ mod tests {
 
     #[test]
     fn current_workspace_marker_wins_over_stale_pin() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut current = entry(Source::Workspace, "Current");
         current.workspace_id = Some("w1".into());
         current.search_terms.push("focused".into());
@@ -1036,7 +1036,7 @@ mod tests {
 
     #[test]
     fn marked_entry_uses_a_yellow_diamond() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let marked = entry(Source::Root, "Marked");
         app.pinned_entries.insert("root:Marked".into());
 
@@ -1048,7 +1048,7 @@ mod tests {
 
     #[test]
     fn mark_marker_wins_over_previous_workspace() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut previous = entry(Source::Workspace, "Previous");
         previous.workspace_id = Some("w2".into());
         previous.action = EntryAction::FocusWorkspace { id: "w2".into() };
@@ -1063,7 +1063,7 @@ mod tests {
 
     #[test]
     fn mark_marker_wins_over_current_workspace() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut current = entry(Source::Workspace, "Current");
         current.workspace_id = Some("w1".into());
         current.action = EntryAction::FocusWorkspace { id: "w1".into() };
@@ -1078,7 +1078,7 @@ mod tests {
 
     #[test]
     fn detailed_rows_only_expand_directory_sources() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         let mut workspace = entry(Source::Workspace, "dir: demo");
         workspace.path = PathBuf::from("/work/demo");
         workspace.subtitle = "agent:blocked · w1 tabs:2 panes:3".into();
@@ -1110,7 +1110,7 @@ mod tests {
 
     #[test]
     fn list_renders_source_groups_as_a_tree() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.entries = vec![
             entry(Source::Agent, "Claude"),
             entry(Source::Agent, "Codex"),
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn vim_mode_uses_normal_keys_then_searches_with_slash() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.config.picker.vim_mode = true;
         handle_key(&mut app, key(KeyCode::Char('j')));
         assert!(app.query.is_empty());
@@ -1160,7 +1160,7 @@ mod tests {
 
     #[test]
     fn vim_filter_search_starts_search_after_source_key() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.config.picker.vim_mode = true;
         app.config.picker.vim_filter_search = true;
 
@@ -1174,7 +1174,7 @@ mod tests {
 
     #[test]
     fn question_mark_toggles_registry_help_overlay() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         handle_key(&mut app, key(KeyCode::Char('?')));
         assert_eq!(app.input_mode, InputMode::Help);
 
@@ -1193,7 +1193,7 @@ mod tests {
 
     #[test]
     fn registry_reports_active_toggle_state() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.preview = true;
         let preview = keybindings(&app)
             .into_iter()
@@ -1205,7 +1205,7 @@ mod tests {
 
     #[test]
     fn registry_maps_ctrl_b_to_mark_without_stealing_enter() {
-        let app = App::new(Config::default(), Theme::load(false));
+        let app = App::new(Config::default(), Theme::load(None, None, false));
         let mark = keybindings(&app)
             .into_iter()
             .find(|binding| binding.command == Command::ToggleMark)
@@ -1226,7 +1226,7 @@ mod tests {
 
     #[test]
     fn compact_footer_groups_movement_and_lists_filters() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.config.picker.vim_mode = true;
         let backend = TestBackend::new(110, 20);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -1241,7 +1241,7 @@ mod tests {
 
     #[test]
     fn input_modes_transition_exclusively() {
-        let mut app = App::new(Config::default(), Theme::load(false));
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
         app.config.picker.vim_mode = true;
         app.config.picker.vim_filter_search = true;
         assert_eq!(app.input_mode, InputMode::Normal);


### PR DESCRIPTION
## Summary
- Read theme name from plugin config; it was ignored.
- Add plugin [theme.custom] tokens; layered over inherited ones.
- Fix macOS /tmp symlink mismatch in two tests.
- Document theme resolution in README and example config.

## Checks
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

Closes #20 