### PR TITLE
Cache canonical entry paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Cache canonical entry paths so filtering and rendering stay responsive on slow filesystems such as WSL-mounted Windows drives.
+
 ## [0.3.4] - 2026-07-29
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -447,7 +447,7 @@ impl App {
 
     pub(crate) fn workspaces_for_entry(&self, e: &Entry) -> &[WorkspaceRef] {
         self.path_to_workspaces
-            .get(&e.key())
+            .get(e.key())
             .map(Vec::as_slice)
             .unwrap_or(&[])
     }
@@ -459,7 +459,7 @@ impl App {
     }
 
     pub(crate) fn matching_dir_workspace(&self, e: &Entry) -> Option<&WorkspaceRef> {
-        self.matching_dir_workspace_by_key(&e.key())
+        self.matching_dir_workspace_by_key(e.key())
     }
 
     fn matching_dir_workspace_by_key(&self, key: &str) -> Option<&WorkspaceRef> {
@@ -797,6 +797,7 @@ fn push_unique(entries: &mut Vec<Entry>, seen: &mut HashSet<String>, incoming: V
 mod tests {
     use std::{
         path::PathBuf,
+        sync::OnceLock,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -809,6 +810,7 @@ mod tests {
             title: title.into(),
             subtitle: String::new(),
             path: PathBuf::from(path),
+            path_key: OnceLock::new(),
             workspace_id: None,
             workspace_label: None,
             agent_target: None,
@@ -840,6 +842,7 @@ mod tests {
             title: "claude · Dotfiles · dotfiles".into(),
             subtitle: format!("{status} · wF:p2 · wF:t2"),
             path: PathBuf::from("/home/fenix/dotfiles"),
+            path_key: OnceLock::new(),
             workspace_id: Some("wF".into()),
             workspace_label: Some("Dotfiles".into()),
             agent_target: Some("term_1".into()),

--- a/src/integrations/command.rs
+++ b/src/integrations/command.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{process::Command, sync::OnceLock};
 
 use serde::Deserialize;
 
@@ -68,6 +68,7 @@ fn entry_from_item(integration: &IntegrationConfig, item: IntegrationItem) -> En
         title: item.title,
         subtitle,
         path,
+        path_key: OnceLock::new(),
         workspace_id: None,
         workspace_label: None,
         agent_target: None,

--- a/src/integrations/herdr_plus.rs
+++ b/src/integrations/herdr_plus.rs
@@ -1,6 +1,7 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use serde_json::Value;
@@ -31,6 +32,7 @@ pub(crate) fn collect_projects() -> Vec<Entry> {
             title: project.name.clone(),
             subtitle: project.description.clone(),
             path: p,
+            path_key: OnceLock::new(),
             workspace_id: None,
             workspace_label: None,
             agent_target: None,
@@ -74,6 +76,7 @@ pub(crate) fn quick_actions_entry() -> Entry {
         title: "Herdr Plus Quick Actions".into(),
         subtitle: "open the Herdr Plus quick-action picker".into(),
         path: env::current_dir().unwrap_or_else(|_| home()),
+        path_key: OnceLock::new(),
         workspace_id: None,
         workspace_label: None,
         agent_target: None,

--- a/src/integrations/sessions.rs
+++ b/src/integrations/sessions.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf, process::Command, sync::OnceLock};
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -84,6 +84,7 @@ fn local_session_entry(session: ListedSession) -> Entry {
         title: session.name.clone(),
         subtitle,
         path,
+        path_key: OnceLock::new(),
         workspace_id: None,
         workspace_label: None,
         agent_target: None,
@@ -107,6 +108,7 @@ fn manual_session_entry(config: &SessionEntryConfig) -> Entry {
         title: config.name.clone(),
         subtitle: format!("local session · {session}"),
         path,
+        path_key: OnceLock::new(),
         workspace_id: None,
         workspace_label: None,
         agent_target: None,
@@ -129,6 +131,7 @@ fn remote_entry(config: &SessionEntryConfig) -> Option<Entry> {
         title: config.name.clone(),
         subtitle: format!("remote Herdr · {target}"),
         path: PathBuf::from(format!("remote:{target}")),
+        path_key: OnceLock::new(),
         workspace_id: None,
         workspace_label: None,
         agent_target: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -114,6 +114,7 @@ pub(crate) struct Entry {
     pub(crate) title: String,
     pub(crate) subtitle: String,
     pub(crate) path: PathBuf,
+    pub(crate) path_key: OnceLock<String>,
     pub(crate) workspace_id: Option<String>,
     pub(crate) workspace_label: Option<String>,
     pub(crate) agent_target: Option<String>,
@@ -124,8 +125,10 @@ pub(crate) struct Entry {
 }
 
 impl Entry {
-    pub(crate) fn key(&self) -> String {
-        canonical_str(&self.path).unwrap_or_else(|| self.path.display().to_string())
+    pub(crate) fn key(&self) -> &str {
+        self.path_key.get_or_init(|| {
+            canonical_str(&self.path).unwrap_or_else(|| self.path.display().to_string())
+        })
     }
 
     pub(crate) fn source_name(&self) -> &str {
@@ -145,6 +148,66 @@ impl Entry {
             self.search_terms.join(" ")
         )
         .to_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        os::unix::fs::symlink,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn test_path(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("herdr-entry-{name}-{suffix}"))
+    }
+
+    fn entry(path: PathBuf) -> Entry {
+        Entry {
+            source: Source::Root,
+            title: "cached".into(),
+            subtitle: String::new(),
+            path,
+            path_key: OnceLock::new(),
+            workspace_id: None,
+            workspace_label: None,
+            agent_target: None,
+            project: None,
+            action: EntryAction::FocusOrCreateDir,
+            source_label: None,
+            search_terms: vec![],
+        }
+    }
+
+    #[test]
+    fn path_key_is_cached_after_first_filesystem_lookup() {
+        let path = test_path("key");
+        fs::create_dir(&path).unwrap();
+        let entry = entry(path.clone());
+
+        let first = entry.key().to_string();
+        fs::remove_dir(&path).unwrap();
+
+        assert_eq!(entry.key(), first);
+    }
+
+    #[test]
+    fn path_key_preserves_symlink_resolution() {
+        let target = test_path("target");
+        let link = test_path("link");
+        fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert_eq!(entry(link.clone()).key(), entry(target.clone()).key());
+
+        fs::remove_file(link).unwrap();
+        fs::remove_dir(target).unwrap();
     }
 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Command,
+    sync::OnceLock,
 };
 
 use serde_json::Value;
@@ -87,6 +88,7 @@ fn workspaces_from_json(
                 title: label.into(),
                 subtitle,
                 path,
+                path_key: OnceLock::new(),
                 workspace_id: Some(id.into()),
                 workspace_label: Some(label.into()),
                 agent_target: None,
@@ -185,6 +187,7 @@ fn agents_from_json(
                 title,
                 subtitle,
                 path,
+                path_key: OnceLock::new(),
                 workspace_id: (!workspace_id.is_empty()).then(|| workspace_id.into()),
                 workspace_label: Some(workspace_label.into()),
                 agent_target: Some(target.into()),
@@ -256,6 +259,7 @@ pub(crate) fn collect_zoxide() -> Vec<Entry> {
                 title: basename(&path),
                 subtitle: line.into(),
                 path,
+                path_key: OnceLock::new(),
                 workspace_id: None,
                 workspace_label: None,
                 agent_target: None,
@@ -288,6 +292,7 @@ fn walk_dirs(path: &Path, depth: usize, out: &mut Vec<Entry>) {
             title: basename(path),
             subtitle: path.display().to_string(),
             path: path.to_path_buf(),
+            path_key: OnceLock::new(),
             workspace_id: None,
             workspace_label: None,
             agent_target: None,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -875,6 +875,7 @@ fn source_color(theme: &Theme, source: &Source) -> Color {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::OnceLock;
 
     use crossterm::event::KeyModifiers;
     use ratatui::backend::TestBackend;
@@ -892,6 +893,7 @@ mod tests {
             title: title.into(),
             subtitle: String::new(),
             path: PathBuf::from(title),
+            path_key: OnceLock::new(),
             workspace_id: None,
             workspace_label: None,
             agent_target: None,


### PR DESCRIPTION
## Summary

- cache each entry's canonical path after its first lookup
- avoid repeated filesystem access during picker filtering and rendering
- preserve canonical path and symlink matching behavior
- document the fix in the changelog

## Why

`Entry::key()` was calling `fs::canonicalize()` on every invocation. The method is reached repeatedly from sorting, pin rendering, preview rendering, and workspace matching. On WSL-mounted Windows paths such as `/mnt/c`, those filesystem calls can make every picker keypress noticeably slow.

The canonical key is now memoized with `OnceLock<String>`, limiting resolution to one lookup per entry while retaining the existing fallback for missing paths.

Fixes #22.

## Testing

- `cargo fmt -- --check`
- `cargo test` (70 passed)
- `cargo build --release`

## Disclosure

The investigation and patch were prepared with assistance from an AI coding agent. I reviewed and tested the result locally; please review the diagnosis and implementation as appropriate.