### PR TITLE
perf: resolve canonical paths and build the matcher once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Keep typing responsive on large indexes by resolving each entry's canonical path once instead of on every sort comparison, and by building the fuzzy matcher once per query instead of once per candidate ([#22](https://github.com/thanhdat77/herdr-navigator/issues/22)).
+
 ## [0.3.4] - 2026-07-29
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,12 +8,21 @@ use crate::{
     config::Config,
     herdr::{herdr_json, notify_done, notify_error, run_herdr},
     integrations::{command, herdr_plus, sessions},
-    matcher::match_score,
+    matcher::Scorer,
     model::{Entry, EntryAction, Source, WorkspaceKind, WorkspaceRef},
     paths::{canonical_str, herdr_plus_quick_actions_dir, home, plugin_config_dir},
     sources::{collect_agents, collect_roots, collect_workspaces, collect_zoxide},
     theme::Theme,
 };
+
+/// One entry that survived filtering, with its sort keys already resolved.
+struct Candidate {
+    previous_pinned: bool,
+    user_pinned: bool,
+    score: i64,
+    source_rank: usize,
+    idx: usize,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InputMode {
@@ -134,7 +143,11 @@ impl App {
             && self.config.jump_back.pin_previous
             && self.query.trim().is_empty()
             && self.source_filter.is_none();
-        let mut scored = Vec::new();
+        // Everything the comparator needs is resolved here, once per candidate.
+        // Deriving it inside `sort_by` instead costs O(n log n) pin lookups, and
+        // a pin lookup canonicalizes a path.
+        let mut scorer = Scorer::new(&self.config.picker.engine, &query.plain);
+        let mut scored: Vec<Candidate> = Vec::new();
         for (idx, e) in self.entries.iter().enumerate() {
             if let Some(sf) = &self.source_filter {
                 if &e.source != sf {
@@ -144,46 +157,41 @@ impl App {
             if !query.filters_match(e) {
                 continue;
             }
-            let hay = e.haystack();
             let bonus = self.config.picker.source_bonus(&e.source)
                 + query.score_bonus(e, use_agent_priority);
-            if query.plain.is_empty() {
-                scored.push((bonus, idx));
-            } else if let Some(score) = match_score(&self.config.picker.engine, &hay, &query.plain)
-            {
-                scored.push((score + bonus, idx));
-            }
+            let score = if query.plain.is_empty() {
+                bonus
+            } else if let Some(score) = scorer.score(&e.haystack()) {
+                score + bonus
+            } else {
+                continue;
+            };
+            scored.push(Candidate {
+                previous_pinned: pin_previous
+                    && e.source == Source::Workspace
+                    && e.workspace_id.as_deref() == self.previous_workspace_id.as_deref(),
+                user_pinned: self.is_pinned(e),
+                score,
+                source_rank: self.config.picker.source_rank(&e.source),
+                idx,
+            });
         }
-        scored.sort_by(|(score_a, idx_a), (score_b, idx_b)| {
-            let user_pinned_a = self.is_pinned(&self.entries[*idx_a]);
-            let user_pinned_b = self.is_pinned(&self.entries[*idx_b]);
-            let previous_pinned_a = pin_previous
-                && self.entries[*idx_a].source == Source::Workspace
-                && self.entries[*idx_a].workspace_id.as_deref()
-                    == self.previous_workspace_id.as_deref();
-            let previous_pinned_b = pin_previous
-                && self.entries[*idx_b].source == Source::Workspace
-                && self.entries[*idx_b].workspace_id.as_deref()
-                    == self.previous_workspace_id.as_deref();
-            previous_pinned_b
-                .cmp(&previous_pinned_a)
-                .then_with(|| user_pinned_b.cmp(&user_pinned_a))
-                .then_with(|| score_b.cmp(score_a))
-                .then_with(|| {
-                    self.config
-                        .picker
-                        .source_rank(&self.entries[*idx_a].source)
-                        .cmp(&self.config.picker.source_rank(&self.entries[*idx_b].source))
-                })
+        scored.sort_by(|a, b| {
+            b.previous_pinned
+                .cmp(&a.previous_pinned)
+                .then_with(|| b.user_pinned.cmp(&a.user_pinned))
+                .then_with(|| b.score.cmp(&a.score))
+                .then_with(|| a.source_rank.cmp(&b.source_rank))
                 .then_with(|| {
                     if agent_view {
-                        idx_a.cmp(idx_b)
+                        a.idx.cmp(&b.idx)
                     } else {
-                        self.entries[*idx_a].title.cmp(&self.entries[*idx_b].title)
+                        self.entries[a.idx].title.cmp(&self.entries[b.idx].title)
                     }
                 })
         });
-        let (scores, filtered): (Vec<_>, Vec<_>) = scored.into_iter().unzip();
+        let (scores, filtered): (Vec<_>, Vec<_>) =
+            scored.into_iter().map(|c| (c.score, c.idx)).unzip();
         self.filtered = filtered;
         self.filtered_scores = scores;
         self.selected = 0;
@@ -447,7 +455,7 @@ impl App {
 
     pub(crate) fn workspaces_for_entry(&self, e: &Entry) -> &[WorkspaceRef] {
         self.path_to_workspaces
-            .get(&e.key())
+            .get(e.key())
             .map(Vec::as_slice)
             .unwrap_or(&[])
     }
@@ -459,7 +467,7 @@ impl App {
     }
 
     pub(crate) fn matching_dir_workspace(&self, e: &Entry) -> Option<&WorkspaceRef> {
-        self.matching_dir_workspace_by_key(&e.key())
+        self.matching_dir_workspace_by_key(e.key())
     }
 
     fn matching_dir_workspace_by_key(&self, key: &str) -> Option<&WorkspaceRef> {
@@ -797,6 +805,7 @@ fn push_unique(entries: &mut Vec<Entry>, seen: &mut HashSet<String>, incoming: V
 mod tests {
     use std::{
         path::PathBuf,
+        sync::OnceLock,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -816,6 +825,7 @@ mod tests {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            canonical: OnceLock::new(),
         }
     }
 
@@ -849,6 +859,7 @@ mod tests {
             },
             source_label: None,
             search_terms: vec!["main ai dot".into()],
+            canonical: OnceLock::new(),
         }
     }
 

--- a/src/integrations/command.rs
+++ b/src/integrations/command.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{process::Command, sync::OnceLock};
 
 use serde::Deserialize;
 
@@ -80,6 +80,7 @@ fn entry_from_item(integration: &IntegrationConfig, item: IntegrationItem) -> En
         source_label: (!matches!(kind.as_str(), "server" | "remote-terminal" | "session"))
             .then(|| integration.label.clone()),
         search_terms: vec![id, kind],
+        canonical: OnceLock::new(),
     }
 }
 

--- a/src/integrations/herdr_plus.rs
+++ b/src/integrations/herdr_plus.rs
@@ -1,6 +1,7 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use serde_json::Value;
@@ -38,6 +39,7 @@ pub(crate) fn collect_projects() -> Vec<Entry> {
             action: EntryAction::OpenProject,
             source_label: None,
             search_terms: vec![],
+            canonical: OnceLock::new(),
         });
     }
     out
@@ -83,6 +85,7 @@ pub(crate) fn quick_actions_entry() -> Entry {
         },
         source_label: None,
         search_terms: vec![],
+        canonical: OnceLock::new(),
     }
 }
 

--- a/src/integrations/sessions.rs
+++ b/src/integrations/sessions.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf, process::Command, sync::OnceLock};
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -94,6 +94,7 @@ fn local_session_entry(session: ListedSession) -> Entry {
         },
         source_label: None,
         search_terms: vec!["local".into(), "session".into()],
+        canonical: OnceLock::new(),
     }
 }
 
@@ -117,6 +118,7 @@ fn manual_session_entry(config: &SessionEntryConfig) -> Entry {
         },
         source_label: None,
         search_terms,
+        canonical: OnceLock::new(),
     }
 }
 
@@ -136,6 +138,7 @@ fn remote_entry(config: &SessionEntryConfig) -> Option<Entry> {
         action: EntryAction::OpenRemote { target },
         source_label: None,
         search_terms,
+        canonical: OnceLock::new(),
     })
 }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -4,17 +4,55 @@ use nucleo_matcher::{
     Config as NucleoConfig, Matcher as NucleoMatcher, Utf32Str,
 };
 
-pub(crate) fn match_score(engine: &str, hay: &str, q: &str) -> Option<i64> {
-    match engine {
-        "skim" => SkimMatcherV2::default().fuzzy_match(hay, q),
-        "simple" => simple_fuzzy_score(hay, q).map(|score| -score),
-        _ => {
-            let mut matcher = NucleoMatcher::new(NucleoConfig::DEFAULT.match_paths());
-            let pattern = Pattern::parse(q, CaseMatching::Ignore, Normalization::Smart);
-            let mut buf = Vec::new();
-            pattern
-                .score(Utf32Str::new(hay, &mut buf), &mut matcher)
-                .map(|score| score as i64)
+/// A fuzzy matcher prepared for one query.
+///
+/// Building the engine and parsing the pattern is not free, so it happens once
+/// per query here instead of once per candidate: `apply_filter` scores every
+/// entry on every keystroke.
+pub(crate) enum Scorer {
+    Nucleo {
+        matcher: Box<NucleoMatcher>,
+        pattern: Pattern,
+        buf: Vec<char>,
+    },
+    Skim {
+        matcher: Box<SkimMatcherV2>,
+        query: String,
+    },
+    Simple {
+        query: String,
+    },
+}
+
+impl Scorer {
+    pub(crate) fn new(engine: &str, query: &str) -> Self {
+        match engine {
+            "skim" => Scorer::Skim {
+                matcher: Box::new(SkimMatcherV2::default()),
+                query: query.to_string(),
+            },
+            "simple" => Scorer::Simple {
+                query: query.to_string(),
+            },
+            _ => Scorer::Nucleo {
+                matcher: Box::new(NucleoMatcher::new(NucleoConfig::DEFAULT.match_paths())),
+                pattern: Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart),
+                buf: Vec::new(),
+            },
+        }
+    }
+
+    pub(crate) fn score(&mut self, hay: &str) -> Option<i64> {
+        match self {
+            Scorer::Nucleo {
+                matcher,
+                pattern,
+                buf,
+            } => pattern
+                .score(Utf32Str::new(hay, buf), matcher)
+                .map(|score| score as i64),
+            Scorer::Skim { matcher, query } => matcher.fuzzy_match(hay, query),
+            Scorer::Simple { query } => simple_fuzzy_score(hay, query).map(|score| -score),
         }
     }
 }
@@ -29,4 +67,33 @@ fn simple_fuzzy_score(hay: &str, q: &str) -> Option<i64> {
         pos += found + qc.len_utf8();
     }
     Some(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_engine_matches_and_rejects() {
+        for engine in ["nucleo", "skim", "simple"] {
+            let mut scorer = Scorer::new(engine, "dot");
+            assert!(
+                scorer
+                    .score("workspace dotfiles /home/u/dotfiles")
+                    .is_some(),
+                "{engine} should match"
+            );
+            assert!(scorer.score("zzz").is_none(), "{engine} should not match");
+        }
+    }
+
+    #[test]
+    fn scorer_is_reusable_across_candidates() {
+        for engine in ["nucleo", "skim", "simple"] {
+            let mut scorer = Scorer::new(engine, "dot");
+            let first = scorer.score("dotfiles");
+            let again = scorer.score("dotfiles");
+            assert_eq!(first, again, "{engine} must be stateless across candidates");
+        }
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -121,11 +121,16 @@ pub(crate) struct Entry {
     pub(crate) action: EntryAction,
     pub(crate) source_label: Option<String>,
     pub(crate) search_terms: Vec<String>,
+    /// Lazily resolved `key()`. `canonicalize` is a syscall and `key()` sits on
+    /// hot paths (filtering, sorting, pin lookups, rendering), so resolve once.
+    pub(crate) canonical: OnceLock<String>,
 }
 
 impl Entry {
-    pub(crate) fn key(&self) -> String {
-        canonical_str(&self.path).unwrap_or_else(|| self.path.display().to_string())
+    pub(crate) fn key(&self) -> &str {
+        self.canonical.get_or_init(|| {
+            canonical_str(&self.path).unwrap_or_else(|| self.path.display().to_string())
+        })
     }
 
     pub(crate) fn source_name(&self) -> &str {
@@ -195,5 +200,71 @@ impl ProjectTab {
                 pane
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env, fs};
+
+    fn dir_entry(path: PathBuf) -> Entry {
+        Entry {
+            source: Source::Zoxide,
+            title: String::new(),
+            subtitle: String::new(),
+            path,
+            workspace_id: None,
+            workspace_label: None,
+            agent_target: None,
+            project: None,
+            action: EntryAction::FocusOrCreateDir,
+            source_label: None,
+            search_terms: vec![],
+            canonical: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn key_resolves_once_and_is_stable() {
+        let dir = env::temp_dir().join(format!("herdr-nav-key-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let entry = dir_entry(dir.clone());
+
+        let first = entry.key();
+        let second = entry.key();
+        assert_eq!(first, second);
+        // Same backing allocation: the second call reused the cache instead of
+        // canonicalizing again.
+        assert!(std::ptr::eq(first, second));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn key_still_resolves_symlinks() {
+        let dir = env::temp_dir().join(format!("herdr-nav-link-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target");
+        fs::create_dir_all(&target).unwrap();
+        let link = dir.join("link");
+
+        #[cfg(unix)]
+        {
+            let _ = fs::remove_file(&link);
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            assert_eq!(dir_entry(link).key(), dir_entry(target).key());
+        }
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn key_falls_back_to_display_for_missing_paths() {
+        let missing = PathBuf::from("/herdr-navigator/does/not/exist");
+        assert_eq!(
+            dir_entry(missing.clone()).key(),
+            missing.display().to_string()
+        );
     }
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Command,
+    sync::OnceLock,
 };
 
 use serde_json::Value;
@@ -94,6 +95,7 @@ fn workspaces_from_json(
                 action: EntryAction::FocusWorkspace { id: id.into() },
                 source_label: None,
                 search_terms,
+                canonical: OnceLock::new(),
             });
         }
     }
@@ -194,6 +196,7 @@ fn agents_from_json(
                 },
                 source_label: None,
                 search_terms,
+                canonical: OnceLock::new(),
             });
         }
     }
@@ -263,6 +266,7 @@ pub(crate) fn collect_zoxide() -> Vec<Entry> {
                 action: EntryAction::FocusOrCreateDir,
                 source_label: None,
                 search_terms: vec![],
+                canonical: OnceLock::new(),
             }
         })
         .collect()
@@ -295,6 +299,7 @@ fn walk_dirs(path: &Path, depth: usize, out: &mut Vec<Entry>) {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            canonical: OnceLock::new(),
         });
     }
     if let Ok(read) = fs::read_dir(path) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -874,7 +874,7 @@ fn source_color(theme: &Theme, source: &Source) -> Color {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::OnceLock};
 
     use crossterm::event::KeyModifiers;
     use ratatui::backend::TestBackend;
@@ -899,6 +899,7 @@ mod tests {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            canonical: OnceLock::new(),
         }
     }
 


### PR DESCRIPTION
Fixes #22.

## The problem

Typing in the picker slows down as the index grows. On my machine the index is 2660 entries (2640 of them from zoxide), on plain ext4 — no WSL or network mounts involved — and each keystroke stalls noticeably.

Two hot paths do work per-comparison or per-candidate that only needs doing once per query.

**1. `Entry::key()` canonicalizes on every call.** It is reached from `apply_filter`'s comparator twice per comparison, via `is_pinned` → `pin_key` → `key()`. Sorting `n` entries therefore issues roughly `2n·log₂(n)` `canonicalize` syscalls per keystroke — about 60,500 for n=2660 — and this happens whether or not any pins exist.

Measured with `std::fs::canonicalize` over the real path set, warm cache:

```
per call:                          5.6 µs
is_pinned calls per keystroke:     ~60,500
=> canonicalize per keystroke:     ~338 ms
```

That is the bulk of the latency. Issue #22 reports it on WSL, where `/mnt/c` makes each call far more expensive; the same code is slow on native Linux too, just less dramatically.

**2. `match_score` rebuilds the matcher per candidate.** It constructed a fresh `NucleoMatcher` and re-parsed the search `Pattern` inside the per-entry loop, so both were built once per entry per keystroke rather than once per query. `SkimMatcherV2::default()` had the same problem on the `skim` engine.

## The change

- **Cache the resolved path per entry** in a `OnceLock<String>`, as suggested in #22. `key()` now returns `&str` and canonicalizes at most once per entry. Entries are rebuilt wholesale by `refresh()`, so the cache cannot outlive the data it was derived from and filesystem changes are still picked up.
- **Resolve each candidate's sort keys during the filter scan** — pin state, score, source rank — into a small `Candidate` struct, and sort over those. The comparator no longer touches the filesystem or allocates. This matters independently of the cache: `pin_key` builds a `String` per call, so the comparator was also doing ~60k allocations per keystroke.
- **Replace `match_score` with a `Scorer`** prepared once per query and reused across candidates.

Ordering is unchanged. The comparator applies the same keys in the same sequence; only where they are computed moved.

## Testing

- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` all clean. 73 tests pass (70 existing, unmodified).
- New tests cover the cache returning a stable value, symlink resolution still working through the cache, the fallback for paths that do not exist, and each engine matching, rejecting, and staying stateless across candidates.

Note: `cargo clippy --all-targets` reports a pre-existing "items after a test module" error in `src/main.rs` on `main` as well; this branch neither adds nor fixes it.