### PR TITLE
fix: stop unbound chords from typing into the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+- `Ctrl-Backspace` deletes the last word of the query.
+
+### Fixed
+- Unbound `Ctrl`/`Alt` chords no longer insert their letter into the query; `Ctrl-Backspace` typed an `h` because terminals send it as `Ctrl-H`.
+
 ## [0.3.4] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Every source can be disabled. Missing optional tools degrade quietly.
 | `Ctrl-B` | Mark or unmark the selected item |
 | `Ctrl-O` | Toggle preview |
 | `Ctrl-U` | Clear query and filter |
+| `Ctrl-Backspace` | Delete the last query word |
 | `?` | Show active keybindings |
 | `Esc` / `Ctrl-C` | Back or close |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -189,6 +189,18 @@ impl App {
         self.selected = 0;
     }
 
+    /// Drop the trailing word of the query, plus any whitespace before it.
+    pub(crate) fn delete_query_word(&mut self) {
+        let trimmed = self.query.trim_end();
+        let cut = trimmed
+            .char_indices()
+            .rev()
+            .find(|(_, c)| c.is_whitespace())
+            .map(|(idx, c)| idx + c.len_utf8())
+            .unwrap_or(0);
+        self.query.truncate(cut);
+    }
+
     pub(crate) fn set_filter(&mut self, source: Option<Source>) {
         self.source_filter = if self.source_filter == source {
             None

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -16,6 +16,7 @@ pub(crate) enum Command {
     StartSearch,
     CycleFilter,
     DeleteChar,
+    DeleteWord,
     Clear,
     CloseWorkspace,
     ToggleMark,
@@ -255,6 +256,19 @@ pub(crate) fn keybindings(app: &App) -> Vec<Keybind> {
             Command::DeleteChar,
             vec![key(KeyCode::Backspace, KeyModifiers::NONE, "⌫")],
             "delete query character",
+            "Actions",
+            None,
+        ),
+        binding(
+            Command::DeleteWord,
+            vec![
+                // Terminals send Ctrl-Backspace as 0x08, which crossterm decodes
+                // as Ctrl-H. Under the kitty keyboard protocol it arrives as a
+                // real Ctrl-Backspace instead, so accept both spellings.
+                key(KeyCode::Backspace, KeyModifiers::CONTROL, "⌃⌫"),
+                key(KeyCode::Char('h'), KeyModifiers::CONTROL, "⌃⌫"),
+            ],
+            "delete query word",
             "Actions",
             None,
         ),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -161,9 +161,14 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Action {
         return Action::Continue;
     }
 
+    // Only plain and shifted characters are text. Without this guard every
+    // unbound chord inserts its letter -- Ctrl-Backspace arrives as Ctrl-H on
+    // most terminals and used to type an "h".
     if let KeyCode::Char(c) = key.code {
-        app.query.push(c);
-        app.apply_filter();
+        if key.modifiers.difference(KeyModifiers::SHIFT).is_empty() {
+            app.query.push(c);
+            app.apply_filter();
+        }
     }
     Action::Continue
 }
@@ -201,6 +206,11 @@ fn execute_command(app: &mut App, command: Command, key: KeyEvent) -> Action {
         }
         Command::DeleteChar => {
             app.query.pop();
+            app.apply_filter();
+            Action::Continue
+        }
+        Command::DeleteWord => {
+            app.delete_query_word();
             app.apply_filter();
             Action::Continue
         }
@@ -876,7 +886,6 @@ fn source_color(theme: &Theme, source: &Source) -> Color {
 mod tests {
     use std::path::PathBuf;
 
-    use crossterm::event::KeyModifiers;
     use ratatui::backend::TestBackend;
 
     use super::*;
@@ -1135,6 +1144,78 @@ mod tests {
         )));
         assert!(text.contains(" ▾ root "));
         assert!(text.contains("  └─ Dotfiles"));
+    }
+
+    #[test]
+    fn modified_chords_never_insert_text() {
+        let mut app = App::new(Config::default(), Theme::load(false));
+
+        // Ctrl-Backspace reaches the app as Ctrl-H on most terminals; it used to
+        // fall through and type an "h".
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL),
+        );
+        assert_eq!(app.query, "");
+
+        // Any other unbound chord is inert too.
+        for code in ['d', 'f', 'k'] {
+            handle_key(
+                &mut app,
+                KeyEvent::new(KeyCode::Char(code), KeyModifiers::CONTROL),
+            );
+            handle_key(
+                &mut app,
+                KeyEvent::new(KeyCode::Char(code), KeyModifiers::ALT),
+            );
+        }
+        assert_eq!(app.query, "");
+
+        // Plain and shifted characters are still text.
+        handle_key(&mut app, key(KeyCode::Char('a')));
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('B'), KeyModifiers::SHIFT),
+        );
+        assert_eq!(app.query, "aB");
+    }
+
+    #[test]
+    fn ctrl_backspace_deletes_a_word_in_both_encodings() {
+        for chord in [
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL),
+        ] {
+            let mut app = App::new(Config::default(), Theme::load(false));
+            app.query = "foo bar".into();
+
+            handle_key(&mut app, chord);
+            assert_eq!(app.query, "foo ");
+
+            handle_key(&mut app, chord);
+            assert_eq!(app.query, "");
+
+            // Empty query stays empty rather than panicking.
+            handle_key(&mut app, chord);
+            assert_eq!(app.query, "");
+        }
+    }
+
+    #[test]
+    fn delete_word_handles_trailing_space_and_multibyte() {
+        let mut app = App::new(Config::default(), Theme::load(false));
+
+        app.query = "foo bar  ".into();
+        app.delete_query_word();
+        assert_eq!(app.query, "foo ");
+
+        app.query = "café naïve".into();
+        app.delete_query_word();
+        assert_eq!(app.query, "café ");
+
+        app.query = "solo".into();
+        app.delete_query_word();
+        assert_eq!(app.query, "");
     }
 
     #[test]


### PR DESCRIPTION
## The problem

Pressing `Ctrl-Backspace` in the picker types an `h` into the query.

The final branch of `handle_key` inserts any `KeyCode::Char` without checking modifiers:

```rust
if let KeyCode::Char(c) = key.code {
    app.query.push(c);
    app.apply_filter();
}
```

Terminals encode `Ctrl-Backspace` as `0x08`. crossterm decodes control bytes `≤ 0x1A` as `Char` + `CONTROL`, so it arrives as `Ctrl-H`. Nothing binds `Ctrl-H`, so it falls through to that branch and inserts a literal `h`.

This is not specific to backspace — **every unbound chord inserts its letter**. `Ctrl-D` types a `d`, `Ctrl-F` types an `f`, `Alt-K` types a `k`. The bound chords (`Ctrl-W`/`A`/`P`/`Q`/`S`/`L`/`Z`/`R`/`X`/`B`/`O`/`U`) are unaffected because they match a binding first.

## The change

- Insert a character only when no modifier other than `Shift` is held, so capitals still type and chords are inert.
- Add `Command::DeleteWord` bound to `Ctrl-Backspace`, which drops the trailing query word plus any whitespace before it.

Both encodings are accepted: `Ctrl-H` for terminals that send `0x08`, and a real `Ctrl-Backspace` for those using the kitty keyboard protocol. The two `KeySpec`s share the `⌃⌫` label, which `key_label` already de-duplicates the same way the `?` binding does.

`Ctrl-W` would be the conventional binding for delete-word, but it is already taken by the Workspaces filter — happy to move it if you would rather rearrange the filter keys. `Ctrl-Backspace` is the key that was both broken and free.

Prior to this, the only query editing was single-char `Backspace` and `Ctrl-U` to clear everything.

## Testing

- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` all clean. 71 tests pass (68 existing, unmodified).
- New tests cover: `Ctrl-H` and other chords not inserting text while plain and shifted characters still do; `Ctrl-Backspace` deleting a word in both encodings, including on an already-empty query; and trailing-whitespace and multi-byte (`café naïve`) handling in the word boundary.
- I confirmed `modified_chords_never_insert_text` fails against the unpatched handler, so it pins the actual regression.

AltGr is unaffected on the supported platforms — on Linux and macOS composed characters arrive without `Ctrl`/`Alt` set. It is only on Windows that AltGr reports as `Ctrl+Alt`, and the plugin declares `platforms = ["linux", "macos"]`.

README keyboard table and CHANGELOG updated.