### PR TITLE
feat(agents): title and search agent rows by tab label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here.
 
 ### Added
 - Navigator-specific `[theme].name` and `[theme.custom]` overrides. Navigator layers inherited Herdr custom tokens beneath its own custom tokens ([#20](https://github.com/thanhdat77/herdr-navigator/issues/20)).
+- Agent rows carry the tab label instead of the directory when the tab is named, and both the tab label and the pane's terminal title are searchable. Panes of one monorepo no longer read identically.
 
 ## [0.3.6] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A single result list can move between live Herdr state and things that are not o
 | **One index across Herdr** | Search workspaces, agents, projects, sessions, remotes, directories, Quick Actions, and integrations together. |
 | **Action-aware Enter** | Results do not just return paths; they focus, create, attach, hand off, invoke, or run. |
 | **Reuse first** | Existing workspaces are focused before new ones are created. Project and directory workspaces sharing a cwd keep separate identities. |
-| **Agents are first-class** | Search agent name, status, workspace, cwd, pane/tab/terminal IDs, session ID, and your own aliases. |
+| **Agents are first-class** | Search agent name, status, workspace, tab label, terminal title, cwd, pane/tab/terminal IDs, session ID, and your own aliases. A named tab titles its agent row, so panes of one monorepo stay distinguishable. |
 | **Extensible without Rust** | Add another tool with a command that returns JSON and a command that opens the selected item. |
 | **No picker dependency** | The Rust/ratatui interface runs in a Herdr-managed pane; `fzf` and `tv` are not runtime requirements. |
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -119,11 +119,41 @@ pub(crate) fn collect_agents(
     aliases: &[crate::config::AgentAliasConfig],
 ) -> Vec<Entry> {
     let agent_json = herdr_json(["agent", "list"]).unwrap_or(Value::Null);
-    agents_from_json(&agent_json, workspaces, aliases)
+    let tab_json = herdr_json(["tab", "list"]).unwrap_or(Value::Null);
+    agents_from_json(
+        &agent_json,
+        &tab_labels_from_json(&tab_json),
+        workspaces,
+        aliases,
+    )
+}
+
+/// Tab labels as `tab_id → label`. Herdr reports an unnamed tab with its number
+/// as the label, which adds nothing to a row, so those are skipped.
+fn tab_labels_from_json(tab_json: &Value) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+    if let Some(tabs) = tab_json.pointer("/result/tabs").and_then(|v| v.as_array()) {
+        for t in tabs {
+            let Some(id) = t.get("tab_id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let label = t.get("label").and_then(|v| v.as_str()).unwrap_or("").trim();
+            let number = t
+                .get("number")
+                .and_then(|v| v.as_i64())
+                .map(|n| n.to_string());
+            if label.is_empty() || number.as_deref() == Some(label) {
+                continue;
+            }
+            labels.insert(id.to_string(), label.to_string());
+        }
+    }
+    labels
 }
 
 fn agents_from_json(
     agent_json: &Value,
+    tab_labels: &HashMap<String, String>,
     workspaces: &[Entry],
     aliases: &[crate::config::AgentAliasConfig],
 ) -> Vec<Entry> {
@@ -166,7 +196,22 @@ fn agents_from_json(
                 .filter(|alias| alias.matches(agent, workspace_label, cwd))
                 .map(|alias| alias.alias.clone())
                 .collect();
-            let title = format!("{agent} · {workspace_label} · {dir}");
+            let tab_label = tab_labels.get(tab).map(String::as_str).unwrap_or("");
+            // Coding agents keep rewriting the terminal title with the task they
+            // are on, which makes it the liveliest search term a pane has.
+            let terminal_title = p
+                .get("terminal_title_stripped")
+                .or_else(|| p.get("terminal_title"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            // A tab label separates panes of one project better than its
+            // directory: inside a monorepo every pane shares workspace and cwd.
+            let title = if tab_label.is_empty() {
+                format!("{agent} · {workspace_label} · {dir}")
+            } else {
+                format!("{agent} · {workspace_label} · {tab_label}")
+            };
             let subtitle = format!("{status} · {pane} · {tab}");
             let mut search_terms = vec![
                 agent.into(),
@@ -182,6 +227,12 @@ fn agents_from_json(
             ];
             if let Some(session) = p.pointer("/agent_session/value").and_then(|v| v.as_str()) {
                 search_terms.push(session.into());
+            }
+            if !tab_label.is_empty() {
+                search_terms.push(tab_label.into());
+            }
+            if !terminal_title.is_empty() {
+                search_terms.push(terminal_title.into());
             }
             search_terms.extend(alias_terms);
             entries.push(Entry {
@@ -337,9 +388,21 @@ mod tests {
             {"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"58f4-session"},
              "agent_status":"working","cwd":"/tmp","focused":true,"foreground_cwd":"/tmp","pane_id":"w43:p1",
              "revision":0,"tab_id":"w43:t1","terminal_id":"term_1","workspace_id":"w43"}]}});
-        let agents = agents_from_json(&agent_json, &entries, &[]);
+        let tab_json = serde_json::json!({"id":"cli:tab:list","result":{"type":"tab_list","tabs":[
+            {"agent_status":"working","focused":true,"label":"primary","number":1,"pane_count":1,"tab_id":"w43:t1","workspace_id":"w43"},
+            {"agent_status":"idle","focused":false,"label":"2","number":2,"pane_count":1,"tab_id":"w43:t2","workspace_id":"w43"}]}});
+        let tab_labels = tab_labels_from_json(&tab_json);
+        assert_eq!(
+            tab_labels.get("w43:t1").map(String::as_str),
+            Some("primary")
+        );
+        assert!(!tab_labels.contains_key("w43:t2")); // unnamed tab: label equals its number
+
+        let agents = agents_from_json(&agent_json, &tab_labels, &entries, &[]);
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].agent_target.as_deref(), Some("w43:p1"));
+        assert_eq!(agents[0].title, "claude · dir: picker · primary");
+        assert!(agents[0].search_terms.contains(&"primary".to_string()));
         assert!(matches!(
             &agents[0].action,
             EntryAction::FocusAgent { target } if target == "w43:p1"


### PR DESCRIPTION
## Summary

- Agent rows read `agent · workspace · dir`, which is the same string for every pane of a monorepo — those panes share both the workspace and the cwd. Three panes of one repo were indistinguishable in the list:

  ```text
  agent  claude · booking · booking   /Users/me/Projects/booking
  agent  claude · booking · booking   /Users/me/Projects/booking
  agent  claude · booking · booking   /Users/me/Projects/booking
  ```

  With the tab labels Herdr already knows:

  ```text
  agent  claude · booking · primary          /Users/me/Projects/booking
  agent  claude · booking · herdr            /Users/me/Projects/booking
  agent  claude · booking · mac mini usage   /Users/me/Projects/booking
  ```

- `collect_agents` fetches `herdr tab list` once (one call covers every workspace) and maps `tab_id -> label`. A named tab takes the directory's place in the row title; the label and the pane's terminal title join the search terms. Coding agents keep rewriting that terminal title with the task they are on, so typing a task name now finds the pane running it.
- An unnamed tab is reported with its number as the label — those are skipped, so their rows keep showing the directory. If `tab list` is unavailable, the map comes back empty and rows fall back to today's behavior, so nothing here depends on a newer Herdr than `min_herdr_version = 0.7.3`.
- The row subtitle keeps its `status · pane · tab` shape, so the detailed-row metadata column and `entry_status` / `entry_metadata` parsing are untouched.
- Tests extend the existing `parses_herdr_workspace_and_agent_list_json` fixture: the `tab list` shape, the unnamed-tab skip, and the row title/search term.
- `README.md` and `CHANGELOG.md` (`Unreleased`) updated.

## Checks

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 96 passed, 3 failed

The three failures are pre-existing on `main` without this change (verified by stashing it): `close_target_matches_entry_kind`, `source_specific_reuse_distinguishes_same_path_workspaces`, and `persisted_workspace_kind_survives_label_changes_and_legacy_labels_migrate`. Their fixtures use `/tmp` paths, and macOS canonicalizes `/tmp` to `/private/tmp`, so the workspace lookups miss. They should pass on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
