### PR TITLE
feat(agents): expose agent task title and custom name in search

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -669,13 +669,14 @@ fn status_text(entry: &Entry) -> String {
         .to_lowercase()
 }
 
+// `!` should reach an agent by either the name Herdr reports or its kind. The
+// title carries whichever one is displayed, so the kind is matched separately.
 fn agent_text(entry: &Entry) -> String {
-    entry
-        .title
-        .split('·')
-        .next()
-        .unwrap_or(&entry.title)
-        .to_string()
+    let displayed = entry.title.split('·').next().unwrap_or(&entry.title);
+    match entry.agent_kind.as_deref() {
+        Some(kind) => format!("{displayed} {kind}"),
+        None => displayed.to_string(),
+    }
 }
 
 fn workspace_text(entry: &Entry) -> String {
@@ -913,6 +914,8 @@ mod tests {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         }
     }
@@ -968,6 +971,8 @@ mod tests {
             },
             source_label: None,
             search_terms: vec!["main ai dot".into()],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         }
     }
@@ -981,6 +986,20 @@ mod tests {
         assert!(!Query::parse("!codex").filters_match(&agent));
         assert!(!Query::parse("!dotfiles").filters_match(&agent));
         assert!(!Query::parse("!claude").filters_match(&entry(Source::Project, "/tmp", "claude")));
+    }
+
+    // A named agent's title leads with the operator-chosen name, so the agent
+    // kind must stay reachable from `!` or `!claude` silently drops every
+    // named agent.
+    #[test]
+    fn agent_token_matches_kind_and_name_for_named_agents() {
+        let mut named = agent_entry();
+        named.title = "reviewer · Dotfiles · dotfiles".into();
+        named.agent_kind = Some("claude".into());
+
+        assert!(Query::parse("!claude").filters_match(&named));
+        assert!(Query::parse("!reviewer").filters_match(&named));
+        assert!(!Query::parse("!codex").filters_match(&named));
     }
 
     #[test]

--- a/src/integrations/command.rs
+++ b/src/integrations/command.rs
@@ -80,6 +80,8 @@ fn entry_from_item(integration: &IntegrationConfig, item: IntegrationItem) -> En
         source_label: (!matches!(kind.as_str(), "server" | "remote-terminal" | "session"))
             .then(|| integration.label.clone()),
         search_terms: vec![id, kind],
+        agent_kind: None,
+        agent_task: None,
         canonical: OnceLock::new(),
     }
 }

--- a/src/integrations/herdr_plus.rs
+++ b/src/integrations/herdr_plus.rs
@@ -39,6 +39,8 @@ pub(crate) fn collect_projects() -> Vec<Entry> {
             action: EntryAction::OpenProject,
             source_label: None,
             search_terms: vec![],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         });
     }
@@ -85,6 +87,8 @@ pub(crate) fn quick_actions_entry() -> Entry {
         },
         source_label: None,
         search_terms: vec![],
+        agent_kind: None,
+        agent_task: None,
         canonical: OnceLock::new(),
     }
 }

--- a/src/integrations/sessions.rs
+++ b/src/integrations/sessions.rs
@@ -94,6 +94,8 @@ fn local_session_entry(session: ListedSession) -> Entry {
         },
         source_label: None,
         search_terms: vec!["local".into(), "session".into()],
+        agent_kind: None,
+        agent_task: None,
         canonical: OnceLock::new(),
     }
 }
@@ -118,6 +120,8 @@ fn manual_session_entry(config: &SessionEntryConfig) -> Entry {
         },
         source_label: None,
         search_terms,
+        agent_kind: None,
+        agent_task: None,
         canonical: OnceLock::new(),
     }
 }
@@ -138,6 +142,8 @@ fn remote_entry(config: &SessionEntryConfig) -> Option<Entry> {
         action: EntryAction::OpenRemote { target },
         source_label: None,
         search_terms,
+        agent_kind: None,
+        agent_task: None,
         canonical: OnceLock::new(),
     })
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -121,6 +121,11 @@ pub(crate) struct Entry {
     pub(crate) action: EntryAction,
     pub(crate) source_label: Option<String>,
     pub(crate) search_terms: Vec<String>,
+    /// Agent kind (`claude`, `opencode`, …) kept separate from `title`, which
+    /// leads with the operator-chosen name when Herdr reports one. The `!`
+    /// filter needs the kind regardless of how the entry is displayed.
+    pub(crate) agent_kind: Option<String>,
+    pub(crate) agent_task: Option<String>,
     /// Lazily resolved `key()`. `canonicalize` is a syscall and `key()` sits on
     /// hot paths (filtering, sorting, pin lookups, rendering), so resolve once.
     pub(crate) canonical: OnceLock<String>,
@@ -221,6 +226,8 @@ mod tests {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         }
     }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -373,8 +373,7 @@ mod tests {
         assert!(agents[0].search_terms.contains(&"term_1".to_string()));
         assert!(agents[0].search_terms.contains(&"58f4-session".to_string()));
         assert!(agents[0].search_terms.contains(&"reviewer".to_string()));
-        // Herdr's "stripped" title drops ANSI, not the agent's activity glyph,
-        // so the task is surfaced verbatim rather than guessing at a prefix.
+        // "stripped" means ANSI-stripped, not glyph-stripped.
         assert!(agents[0]
             .search_terms
             .contains(&"◐ Fix buildSrc consumer surface".to_string()));

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -107,6 +107,8 @@ fn workspaces_from_json(
                 action: EntryAction::FocusWorkspace { id: id.into() },
                 source_label: None,
                 search_terms,
+                agent_kind: None,
+                agent_task: None,
                 canonical: OnceLock::new(),
             });
         }
@@ -161,12 +163,23 @@ fn agents_from_json(
                 .unwrap_or(workspace_id);
             let path = PathBuf::from(cwd);
             let dir = basename(&path);
+            // A blank name must fall back to the kind; it would otherwise
+            // leave the title leading with an empty ` · ` segment.
+            let agent_name = p
+                .get("name")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.trim().is_empty());
+            let task_title = p
+                .get("terminal_title_stripped")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.trim().is_empty());
             let alias_terms: Vec<String> = aliases
                 .iter()
                 .filter(|alias| alias.matches(agent, workspace_label, cwd))
                 .map(|alias| alias.alias.clone())
                 .collect();
-            let title = format!("{agent} · {workspace_label} · {dir}");
+            let display_agent = agent_name.unwrap_or(agent);
+            let title = format!("{display_agent} · {workspace_label} · {dir}");
             let subtitle = format!("{status} · {pane} · {tab}");
             let mut search_terms = vec![
                 agent.into(),
@@ -183,6 +196,12 @@ fn agents_from_json(
             if let Some(session) = p.pointer("/agent_session/value").and_then(|v| v.as_str()) {
                 search_terms.push(session.into());
             }
+            if let Some(name) = agent_name {
+                search_terms.push(name.into());
+            }
+            if let Some(task) = task_title {
+                search_terms.push(task.into());
+            }
             search_terms.extend(alias_terms);
             entries.push(Entry {
                 source: Source::Agent,
@@ -198,6 +217,8 @@ fn agents_from_json(
                 },
                 source_label: None,
                 search_terms,
+                agent_kind: Some(agent.into()),
+                agent_task: task_title.map(String::from),
                 canonical: OnceLock::new(),
             });
         }
@@ -268,6 +289,8 @@ pub(crate) fn collect_zoxide() -> Vec<Entry> {
                 action: EntryAction::FocusOrCreateDir,
                 source_label: None,
                 search_terms: vec![],
+                agent_kind: None,
+                agent_task: None,
                 canonical: OnceLock::new(),
             }
         })
@@ -301,6 +324,8 @@ fn walk_dirs(path: &Path, depth: usize, out: &mut Vec<Entry>) {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         });
     }
@@ -335,8 +360,9 @@ mod tests {
 
         let agent_json = serde_json::json!({"id":"cli:agent:list","result":{"type":"agent_list","agents":[
             {"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"58f4-session"},
-             "agent_status":"working","cwd":"/tmp","focused":true,"foreground_cwd":"/tmp","pane_id":"w43:p1",
-             "revision":0,"tab_id":"w43:t1","terminal_id":"term_1","workspace_id":"w43"}]}});
+             "agent_status":"working","cwd":"/tmp","focused":true,"foreground_cwd":"/tmp","name":"reviewer","pane_id":"w43:p1",
+             "revision":0,"tab_id":"w43:t1","terminal_id":"term_1",
+             "terminal_title_stripped":"◐ Fix buildSrc consumer surface","workspace_id":"w43"}]}});
         let agents = agents_from_json(&agent_json, &entries, &[]);
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].agent_target.as_deref(), Some("w43:p1"));
@@ -346,7 +372,36 @@ mod tests {
         ));
         assert!(agents[0].search_terms.contains(&"term_1".to_string()));
         assert!(agents[0].search_terms.contains(&"58f4-session".to_string()));
+        assert!(agents[0].search_terms.contains(&"reviewer".to_string()));
+        // Herdr's "stripped" title drops ANSI, not the agent's activity glyph,
+        // so the task is surfaced verbatim rather than guessing at a prefix.
+        assert!(agents[0]
+            .search_terms
+            .contains(&"◐ Fix buildSrc consumer surface".to_string()));
+        assert_eq!(
+            agents[0].agent_task.as_deref(),
+            Some("◐ Fix buildSrc consumer surface")
+        );
+        assert_eq!(agents[0].agent_kind.as_deref(), Some("claude"));
+        assert!(agents[0].title.starts_with("reviewer · "));
         assert!(agents[0].subtitle.starts_with("working"));
+    }
+
+    // Herdr omits `name` for unnamed agents; the kind has to carry the title.
+    #[test]
+    fn unnamed_and_blank_named_agents_fall_back_to_the_agent_kind() {
+        let agent_json = serde_json::json!({"id":"cli:agent:list","result":{"type":"agent_list","agents":[
+            {"agent":"opencode","agent_status":"idle","cwd":"/tmp","pane_id":"w1:p1","tab_id":"w1:t1",
+             "terminal_id":"term_1","workspace_id":"w1"},
+            {"agent":"codex","agent_status":"idle","cwd":"/tmp","name":"   ","pane_id":"w2:p1","tab_id":"w2:t1",
+             "terminal_id":"term_2","terminal_title_stripped":"  ","workspace_id":"w2"}]}});
+        let agents = agents_from_json(&agent_json, &[], &[]);
+
+        assert_eq!(agents.len(), 2);
+        assert!(agents[0].title.starts_with("opencode · "));
+        assert!(agents[1].title.starts_with("codex · "));
+        assert_eq!(agents[1].agent_task, None);
+        assert!(!agents[1].search_terms.iter().any(|t| t.trim().is_empty()));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -886,6 +886,9 @@ fn preview_text(app: &App, e: &Entry) -> String {
     if let Some(target) = &e.agent_target {
         lines.push(format!("agent target: {target}"));
     }
+    if let Some(task) = &e.agent_task {
+        lines.push(format!("task: {task}"));
+    }
     if e.source == Source::Agent {
         lines.push(
             "agent filters: @ all agents (configured sort), !agent, @workspace/status, /path"
@@ -985,6 +988,8 @@ mod tests {
             action: EntryAction::FocusOrCreateDir,
             source_label: None,
             search_terms: vec![],
+            agent_kind: None,
+            agent_task: None,
             canonical: OnceLock::new(),
         }
     }


### PR DESCRIPTION
## What

Herdr's `agent list` JSON carries `terminal_title_stripped` (the agent's current task) and `name` (the operator-chosen identity). Navigator was not reading them. This change puts both into search and shows the name in the display title when present.

## Why

When three `opencode` agents run side by side, their display titles are identical except for workspace and directory. You have to scan pane IDs or paths to tell them apart. Herdr already knows what each agent is doing and what you called it.

The roadmap says new features should reduce the cost of switching context. Searching by task title does that. Terminal titles are volatile, but that is fine for a search you are doing right now.

## Changes

- `Entry.agent_task` stores `terminal_title_stripped`, goes into `search_terms`, shows in the preview pane as `task: ...`.
- `Entry.agent_kind` stores the agent kind separately from the display title. The `!agent` filter needs it because the title now leads with `name` when present, so `!claude` would otherwise search for "reviewer" and match nothing.
- Display title uses `name` when present, falling back to the agent kind. Before: `claude · environments · environments`. After: `buildsrc-l1 · environments · environments`.
- Blank `name` and blank `task_title` fall back to kind and `None` to avoid empty ` · ` segments in titles.
- All 12 `Entry` construction sites updated. Non-agent sources set both fields to `None`.

## Verification

98 tests pass. The 3 failing tests fail identically on a clean checkout of `main`; they are macOS path canonicalization issues that do not affect CI (Linux).

New tests cover named agents with task titles, unnamed agents falling back to kind, and blank-named agents with blank task titles.

## What this does not do

- No structured search prefix for task titles. The fuzzy haystack covers it.
- No display of task titles in the list rows. They are volatile and can be long. They show in the preview pane only.
- No stripping of activity glyphs from `terminal_title_stripped`. "stripped" means ANSI-stripped, not glyph-stripped.