### PR TITLE
feat: show pane session titles on agent rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- Agent rows show the pane's session title when one is set (`title · agent` instead of `agent · workspace · dir`), and the title joins the fuzzy search terms.
+
+### Added
 - Navigator-specific `[theme].name` and `[theme.custom]` overrides. Navigator layers inherited Herdr custom tokens beneath its own custom tokens ([#20](https://github.com/thanhdat77/herdr-navigator/issues/20)).
 
 ## [0.3.6] - 2026-08-11

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A single result list can move between live Herdr state and things that are not o
 | **One index across Herdr** | Search workspaces, agents, projects, sessions, remotes, directories, Quick Actions, and integrations together. |
 | **Action-aware Enter** | Results do not just return paths; they focus, create, attach, hand off, invoke, or run. |
 | **Reuse first** | Existing workspaces are focused before new ones are created. Project and directory workspaces sharing a cwd keep separate identities. |
-| **Agents are first-class** | Search agent name, status, workspace, cwd, pane/tab/terminal IDs, session ID, and your own aliases. |
+| **Agents are first-class** | Rows lead with the pane's session title when one is set. Search agent name, title, status, workspace, cwd, pane/tab/terminal IDs, session ID, and your own aliases. |
 | **Extensible without Rust** | Add another tool with a command that returns JSON and a command that opens the selected item. |
 | **No picker dependency** | The Rust/ratatui interface runs in a Herdr-managed pane; `fzf` and `tv` are not runtime requirements. |
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -166,7 +166,15 @@ fn agents_from_json(
                 .filter(|alias| alias.matches(agent, workspace_label, cwd))
                 .map(|alias| alias.alias.clone())
                 .collect();
-            let title = format!("{agent} · {workspace_label} · {dir}");
+            let pane_title = p
+                .get("title")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|t| !t.is_empty());
+            let title = match pane_title {
+                Some(pane_title) => format!("{pane_title} · {agent}"),
+                None => format!("{agent} · {workspace_label} · {dir}"),
+            };
             let subtitle = format!("{status} · {pane} · {tab}");
             let mut search_terms = vec![
                 agent.into(),
@@ -182,6 +190,9 @@ fn agents_from_json(
             ];
             if let Some(session) = p.pointer("/agent_session/value").and_then(|v| v.as_str()) {
                 search_terms.push(session.into());
+            }
+            if let Some(pane_title) = pane_title {
+                search_terms.push(pane_title.into());
             }
             search_terms.extend(alias_terms);
             entries.push(Entry {
@@ -336,10 +347,18 @@ mod tests {
         let agent_json = serde_json::json!({"id":"cli:agent:list","result":{"type":"agent_list","agents":[
             {"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"58f4-session"},
              "agent_status":"working","cwd":"/tmp","focused":true,"foreground_cwd":"/tmp","pane_id":"w43:p1",
-             "revision":0,"tab_id":"w43:t1","terminal_id":"term_1","workspace_id":"w43"}]}});
+             "revision":0,"tab_id":"w43:t1","terminal_id":"term_1","workspace_id":"w43"},
+            {"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"titled-session"},
+             "agent_status":"idle","cwd":"/tmp","focused":false,"foreground_cwd":"/tmp","pane_id":"w43:p2",
+             "revision":0,"tab_id":"w43:t1","terminal_id":"term_2","title":"Fix checkout race",
+             "tokens":{"title":"Fix checkout race"},"workspace_id":"w43"}]}});
         let agents = agents_from_json(&agent_json, &entries, &[]);
-        assert_eq!(agents.len(), 1);
+        assert_eq!(agents.len(), 2);
         assert_eq!(agents[0].agent_target.as_deref(), Some("w43:p1"));
+        assert_eq!(agents[1].title, "Fix checkout race · claude");
+        assert!(agents[1]
+            .search_terms
+            .contains(&"Fix checkout race".to_string()));
         assert!(matches!(
             &agents[0].action,
             EntryAction::FocusAgent { target } if target == "w43:p1"


### PR DESCRIPTION
## What changed

Agent rows in the picker showed only `agent · workspace · dir`, so multiple panes running the same agent in the same directory were indistinguishable:

```
✓ claude · ~ · user
✓ grok · ~ · user
✓ claude · ~ · user
```

`herdr agent list` already returns the pane's `title` (set by title plugins or `pane report-metadata`), but the navigator never read it. With this change, a row leads with the session title when one is set and falls back to the old format when not:

```
✓ Always Trust Workspace · claude
✓ Welcome the AI Challenger · grok
✓ Fix Claude Code Renamer · claude
```

The title is also added to the row's fuzzy search terms, so typing part of it finds the agent.

## Notes

- Extended the `parses_herdr_workspace_and_agent_list_json` fixture test with a titled agent asserting the new row title and search term.
- `cargo fmt --check` and `cargo clippy -- -D warnings` are clean. Test suite: 96 pass; the 3 failures in `close_target_matches_entry_kind`, `source_specific_reuse_distinguishes_same_path_workspaces`, and `persisted_workspace_kind_survives_label_changes_and_legacy_labels_migrate` also fail on an unmodified checkout on macOS (`/tmp` canonicalizes to `/private/tmp`) and are unrelated.
- CHANGELOG updated under Unreleased; README agents row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)