### PR TITLE
feat(picker): add centered popup open action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- `herdr-navigator.open-popup` action and `picker-popup` pane open the picker as a centered 80% × 80% popup over the focused workspace instead of a full-screen overlay. Transient like the overlay (closes on `Enter`/`Esc`) and launch-or-focus within the focused workspace.
 - Navigator-specific `[theme].name` and `[theme.custom]` overrides. Navigator layers inherited Herdr custom tokens beneath its own custom tokens ([#20](https://github.com/thanhdat77/herdr-navigator/issues/20)).
 
 ## [0.3.6] - 2026-08-11

--- a/README.md
+++ b/README.md
@@ -203,6 +203,26 @@ command = "herdr-navigator.open-side"
 description = "navigator side pane"
 ```
 
+### Centered popup
+
+Float Navigator over your work instead of taking over the whole pane. The popup opens centered at 80% × 80% of the focused workspace, so the surrounding panes stay visible behind it. Like the overlay it is transient — `Enter` or `Esc` closes it.
+
+```bash
+herdr plugin action invoke herdr-navigator.open-popup
+```
+
+Optional binding:
+
+```toml
+[[keys.command]]
+key = "prefix+alt+t"
+type = "plugin_action"
+command = "herdr-navigator.open-popup"
+description = "navigator popup"
+```
+
+Invoking `open-popup` again focuses the existing popup in the current workspace instead of opening a duplicate, matching the overlay's launch-or-focus behavior.
+
 ## Configuration
 
 Navigator writes a fully commented config on first run:

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -21,6 +21,12 @@ contexts = ["workspace", "global"]
 command = ["./target/release/herdr-navigator", "open-side"]
 
 [[actions]]
+id = "open-popup"
+title = "Herdr Navigator: open popup"
+contexts = ["workspace", "global"]
+command = ["./target/release/herdr-navigator", "open-popup"]
+
+[[actions]]
 id = "jump-back"
 title = "Herdr Navigator: jump back"
 contexts = ["workspace", "global"]
@@ -40,3 +46,14 @@ id = "picker-side"
 title = "Navigator Side"
 placement = "split"
 command = ["./target/release/herdr-navigator", "ui", "--side"]
+
+# Centered popup variant: floats over the focused workspace at 80% x 80%
+# without replacing it like the overlay. Transient like the overlay (closes on
+# Enter/Esc). Title must stay in sync with POPUP_PANE_LABEL in src/main.rs.
+[[panes]]
+id = "picker-popup"
+title = "Navigator Popup"
+placement = "popup"
+width = "80%"
+height = "80%"
+command = ["./target/release/herdr-navigator", "ui"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,12 @@ fn main() {
     match env::args().nth(1).as_deref() {
         Some("open") => open_picker(),
         Some("open-side") => open_side_picker(),
+        Some("open-popup") => open_popup_picker(),
         Some("jump-back") => jump_back(),
         Some("ui") => run_ui(env::args().nth(2).as_deref() == Some("--side")),
         Some("list") => debug_list(),
         _ => {
-            eprintln!("usage: herdr-navigator <open|open-side|jump-back|ui|list>");
+            eprintln!("usage: herdr-navigator <open|open-side|open-popup|jump-back|ui|list>");
             process::exit(2);
         }
     }
@@ -41,6 +42,7 @@ fn main() {
 // as labels in `pane list`.
 const PICKER_PANE_LABEL: &str = "Herdr Navigator";
 const SIDE_PANE_LABEL: &str = "Navigator Side";
+const POPUP_PANE_LABEL: &str = "Navigator Popup";
 
 enum PickerDecision {
     Open,
@@ -78,10 +80,40 @@ fn picker_pane_decision(pane_json: &serde_json::Value) -> PickerDecision {
         .unwrap_or(PickerDecision::Open)
 }
 
+fn popup_pane_decision(pane_json: &serde_json::Value) -> PickerDecision {
+    pane_in_focused_workspace(pane_json, POPUP_PANE_LABEL)
+        .and_then(|(_, picker)| picker.get("pane_id")?.as_str())
+        .map(|id| PickerDecision::Focus(id.into()))
+        .unwrap_or(PickerDecision::Open)
+}
+
 fn open_picker() -> ! {
     let json = herdr::herdr_json(["pane", "list"]).unwrap_or(serde_json::Value::Null);
     match picker_pane_decision(&json) {
         PickerDecision::Open => open_plugin_pane("picker", &["--focus"]),
+        PickerDecision::Focus(id) => run_plugin_pane_cmd("focus", &id),
+    }
+}
+
+// Launch-or-focus the popup picker within the focused workspace, mirroring the
+// overlay's `open` action but with a centered `popup` placement (80% x 80%)
+// instead of a full-screen overlay. Transient: closes on Enter/Esc like the
+// overlay, unlike the persistent side pane.
+fn open_popup_picker() -> ! {
+    let json = herdr::herdr_json(["pane", "list"]).unwrap_or(serde_json::Value::Null);
+    match popup_pane_decision(&json) {
+        PickerDecision::Open => open_plugin_pane(
+            "picker-popup",
+            &[
+                "--placement",
+                "popup",
+                "--width",
+                "80%",
+                "--height",
+                "80%",
+                "--focus",
+            ],
+        ),
         PickerDecision::Focus(id) => run_plugin_pane_cmd("focus", &id),
     }
 }
@@ -230,6 +262,39 @@ mod tests {
         ]);
         assert!(matches!(
             picker_pane_decision(&other_workspace),
+            PickerDecision::Open
+        ));
+    }
+
+    #[test]
+    fn popup_picker_opens_once_then_focuses_existing_in_focused_workspace() {
+        let no_popup = pane_list(vec![pane("w1:p1", "w1", None, true)]);
+        assert!(matches!(
+            popup_pane_decision(&no_popup),
+            PickerDecision::Open
+        ));
+
+        let existing_popup = pane_list(vec![
+            pane("w1:p1", "w1", None, true),
+            pane("w1:p2", "w1", Some(POPUP_PANE_LABEL), false),
+        ]);
+        assert!(
+            matches!(popup_pane_decision(&existing_popup), PickerDecision::Focus(id) if id == "w1:p2")
+        );
+
+        // A popup in another workspace does not count; open a fresh one here.
+        let other_workspace = pane_list(vec![
+            pane("w1:p1", "w1", None, true),
+            pane("w2:p2", "w2", Some(POPUP_PANE_LABEL), false),
+        ]);
+        assert!(matches!(
+            popup_pane_decision(&other_workspace),
+            PickerDecision::Open
+        ));
+
+        // A null/empty pane list degrades to Open.
+        assert!(matches!(
+            popup_pane_decision(&serde_json::Value::Null),
             PickerDecision::Open
         ));
     }


### PR DESCRIPTION
## Summary

Adds a third way to open Navigator: a **centered popup** that floats over the focused workspace at 80% × 80%, instead of the full-screen overlay or the persistent side split.

- New action: `herdr-navigator.open-popup`
- New pane: `picker-popup` (`placement = "popup"`, `width = "80%"`, `height = "80%"`)
- Launch-or-focus within the focused workspace (mirrors the overlay's `open`): invoking `open-popup` again focuses the existing popup instead of opening a duplicate.
- Transient like the overlay — `Enter`/`Esc` closes it. Unlike `open-side`, it does not persist after `Enter`.

## Why

The overlay replaces the whole pane; the side pane sticks around after `Enter`. A popup is the middle ground: a large, centered fuzzy picker that keeps the surrounding panes visible behind it — useful when you want to glance at Navigator without losing context of the workspace you're working in.

## Placement details (verified against Herdr source)

- `PluginPanePlacement` enum: `overlay` (default) | `popup` | `split` | `tab` | `zoomed` (`src/api/schema/plugins.rs`)
- `plugin pane open` CLI accepts `--placement popup --width 80% --height 80% --focus`; `PopupSize` takes terminal cells or percentages (`src/cli/plugin.rs`)
- The manifest pane declares `placement/width/height`; `open_popup_picker` also passes them explicitly at open time, matching the existing `open_side_picker` pattern.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo build --release`
- [x] New unit test `popup_picker_opens_once_then_focuses_existing_in_focused_workspace` covers: open when absent, focus when present in focused workspace, open (not focus) when present in another workspace, degrade to open on null pane list.
- [x] No regressions: the 3 pre-existing failures on `main` (`app::close_target_matches_entry_kind`, `app::source_specific_reuse_distinguishes_same_path_workspaces`, `sources::persisted_workspace_kind_survives_label_changes_and_legacy_labels_migrate`) are unchanged by this PR — confirmed by running `cargo test` on `main` before branching.

## Manual verification (reviewer)

```bash
cargo build --release
herdr plugin link "$PWD"
herdr plugin action invoke herdr-navigator.open-popup
# invoke again -> focuses existing popup, no duplicate
# Enter / Esc closes it
```

## Naming / size rationale

- **Action `open-popup`** mirrors the existing `open-side` naming convention.
- **Pane `picker-popup`** mirrors `picker-side`; label `Navigator Popup` follows `Navigator Side`.
- **80% × 80%** leaves a visible margin so the underlying workspace frames the popup, reinforcing the "floating over my work" mental model; large enough for detailed rows and long paths. Sizes are declarative in the manifest and easy to make configurable later if needed.

## CHANGELOG

Updated under `Unreleased`.
