### PR TITLE
feat(navigation): add PageUp/PageDown list paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- `herdr-navigator.open-popup` action and `picker-popup` pane open the picker as a centered 80% × 80% popup over the focused workspace instead of a full-screen overlay. Transient like the overlay (closes on `Enter`/`Esc`) and launch-or-focus within the focused workspace.
 - Navigator-specific `[theme].name` and `[theme.custom]` overrides. Navigator layers inherited Herdr custom tokens beneath its own custom tokens ([#20](https://github.com/thanhdat77/herdr-navigator/issues/20)).
 
 ## [0.3.6] - 2026-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- `PageUp` / `PageDown` move the selection by one visible page in addition to `Up` / `Down`.
 - `herdr-navigator.open-popup` action and `picker-popup` pane open the picker as a centered 80% × 80% popup over the focused workspace instead of a full-screen overlay. Transient like the overlay (closes on `Enter`/`Esc`) and launch-or-focus within the focused workspace.
 - Navigator-specific `[theme].name` and `[theme.custom]` overrides. Navigator layers inherited Herdr custom tokens beneath its own custom tokens ([#20](https://github.com/thanhdat77/herdr-navigator/issues/20)).
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,26 @@ command = "herdr-navigator.open-side"
 description = "navigator side pane"
 ```
 
+### Centered popup
+
+Float Navigator over your work instead of taking over the whole pane. The popup opens centered at 80% × 80% of the focused workspace, so the surrounding panes stay visible behind it. Like the overlay it is transient — `Enter` or `Esc` closes it.
+
+```bash
+herdr plugin action invoke herdr-navigator.open-popup
+```
+
+Optional binding:
+
+```toml
+[[keys.command]]
+key = "prefix+alt+t"
+type = "plugin_action"
+command = "herdr-navigator.open-popup"
+description = "navigator popup"
+```
+
+Invoking `open-popup` again focuses the existing popup in the current workspace instead of opening a duplicate, matching the overlay's launch-or-focus behavior.
+
 ## Configuration
 
 Navigator writes a fully commented config on first run:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Every source can be disabled. Missing optional tools degrade quietly.
 | `Enter` | Open selected item normally |
 | `Alt-Enter` | Apply `picker.directory_template` to the selected zoxide/root directory |
 | `Up` / `Down` | Move selection |
+| `PageUp` / `PageDown` | Move selection by one page |
 | `Tab` | Cycle source filters |
 | `Ctrl-W` | Workspaces |
 | `Ctrl-A` / `@` | Agents, using configured status order |

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -21,6 +21,12 @@ contexts = ["workspace", "global"]
 command = ["./target/release/herdr-navigator", "open-side"]
 
 [[actions]]
+id = "open-popup"
+title = "Herdr Navigator: open popup"
+contexts = ["workspace", "global"]
+command = ["./target/release/herdr-navigator", "open-popup"]
+
+[[actions]]
 id = "jump-back"
 title = "Herdr Navigator: jump back"
 contexts = ["workspace", "global"]
@@ -40,3 +46,14 @@ id = "picker-side"
 title = "Navigator Side"
 placement = "split"
 command = ["./target/release/herdr-navigator", "ui", "--side"]
+
+# Centered popup variant: floats over the focused workspace at 80% x 80%
+# without replacing it like the overlay. Transient like the overlay (closes on
+# Enter/Esc). Title must stay in sync with POPUP_PANE_LABEL in src/main.rs.
+[[panes]]
+id = "picker-popup"
+title = "Navigator Popup"
+placement = "popup"
+width = "80%"
+height = "80%"
+command = ["./target/release/herdr-navigator", "ui"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,6 +49,7 @@ pub(crate) struct App {
     pub(crate) pinned_entries: HashSet<String>,
     pub(crate) spinner_tick: u32,
     pub(crate) update_available: Option<String>,
+    pub(crate) list_height: u16,
 }
 
 impl App {
@@ -71,6 +72,7 @@ impl App {
             pinned_entries: HashSet::new(),
             spinner_tick: 0,
             update_available: None,
+            list_height: 0,
         }
     }
 
@@ -253,6 +255,21 @@ impl App {
     }
     pub(crate) fn prev(&mut self) {
         self.selected = self.selected.saturating_sub(1);
+    }
+    /// Page size in entries: the number of rows the last render could show.
+    /// Falls back to a sane default before the first frame is drawn.
+    fn page_size(&self) -> usize {
+        self.list_height.max(1) as usize
+    }
+    pub(crate) fn page_down(&mut self) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        let max = self.filtered.len() - 1;
+        self.selected = self.selected.saturating_add(self.page_size()).min(max);
+    }
+    pub(crate) fn page_up(&mut self) {
+        self.selected = self.selected.saturating_sub(self.page_size());
     }
     pub(crate) fn selected_entry(&self) -> Option<&Entry> {
         self.filtered
@@ -1046,6 +1063,66 @@ mod tests {
         assert_eq!(app.source_filter, Some(Source::Workspace));
         app.cycle_filter();
         assert_eq!(app.source_filter, Some(Source::Project));
+    }
+
+    #[test]
+    fn page_down_advances_by_list_height_and_clamps_at_end() {
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
+        app.entries = (0..30)
+            .map(|i| entry(Source::Workspace, &format!("/p{i}"), &format!("p{i}")))
+            .collect();
+        app.apply_filter();
+        assert_eq!(app.selected, 0);
+
+        // No recorded height yet -> page size falls back to 1.
+        app.list_height = 0;
+        app.page_down();
+        assert_eq!(app.selected, 1);
+
+        // A 10-row list pages by 10 entries.
+        app.list_height = 10;
+        app.page_down();
+        assert_eq!(app.selected, 11);
+        app.page_down();
+        assert_eq!(app.selected, 21);
+        // Clamps at the last entry (index 29).
+        app.page_down();
+        assert_eq!(app.selected, 29);
+        app.page_down();
+        assert_eq!(app.selected, 29);
+    }
+
+    #[test]
+    fn page_up_moves_back_by_list_height_and_clamps_at_zero() {
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
+        app.entries = (0..30)
+            .map(|i| entry(Source::Workspace, &format!("/p{i}"), &format!("p{i}")))
+            .collect();
+        app.apply_filter();
+        app.selected = 29;
+
+        app.list_height = 10;
+        app.page_up();
+        assert_eq!(app.selected, 19);
+        app.page_up();
+        assert_eq!(app.selected, 9);
+        // Clamps at zero.
+        app.page_up();
+        assert_eq!(app.selected, 0);
+        app.page_up();
+        assert_eq!(app.selected, 0);
+    }
+
+    #[test]
+    fn page_movement_is_noop_on_empty_results() {
+        let mut app = App::new(Config::default(), Theme::load(None, None, false));
+        app.entries = vec![];
+        app.apply_filter();
+        app.list_height = 10;
+        app.page_down();
+        assert_eq!(app.selected, 0);
+        app.page_up();
+        assert_eq!(app.selected, 0);
     }
 
     #[test]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -13,6 +13,8 @@ pub(crate) enum Command {
     OpenTemplate,
     MoveUp,
     MoveDown,
+    PageUp,
+    PageDown,
     StartSearch,
     CycleFilter,
     DeleteChar,
@@ -207,6 +209,20 @@ pub(crate) fn keybindings(app: &App) -> Vec<Keybind> {
             "move down",
             "Navigation",
             Some("up/down"),
+        ),
+        binding(
+            Command::PageUp,
+            vec![key(KeyCode::PageUp, KeyModifiers::NONE, "PgUp")],
+            "page up",
+            "Navigation",
+            None,
+        ),
+        binding(
+            Command::PageDown,
+            vec![key(KeyCode::PageDown, KeyModifiers::NONE, "PgDn")],
+            "page down",
+            "Navigation",
+            None,
         ),
     ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,12 @@ fn main() {
     match env::args().nth(1).as_deref() {
         Some("open") => open_picker(),
         Some("open-side") => open_side_picker(),
+        Some("open-popup") => open_popup_picker(),
         Some("jump-back") => jump_back(),
         Some("ui") => run_ui(env::args().nth(2).as_deref() == Some("--side")),
         Some("list") => debug_list(),
         _ => {
-            eprintln!("usage: herdr-navigator <open|open-side|jump-back|ui|list>");
+            eprintln!("usage: herdr-navigator <open|open-side|open-popup|jump-back|ui|list>");
             process::exit(2);
         }
     }
@@ -41,6 +42,7 @@ fn main() {
 // as labels in `pane list`.
 const PICKER_PANE_LABEL: &str = "Herdr Navigator";
 const SIDE_PANE_LABEL: &str = "Navigator Side";
+const POPUP_PANE_LABEL: &str = "Navigator Popup";
 
 enum PickerDecision {
     Open,
@@ -78,10 +80,40 @@ fn picker_pane_decision(pane_json: &serde_json::Value) -> PickerDecision {
         .unwrap_or(PickerDecision::Open)
 }
 
+fn popup_pane_decision(pane_json: &serde_json::Value) -> PickerDecision {
+    pane_in_focused_workspace(pane_json, POPUP_PANE_LABEL)
+        .and_then(|(_, picker)| picker.get("pane_id")?.as_str())
+        .map(|id| PickerDecision::Focus(id.into()))
+        .unwrap_or(PickerDecision::Open)
+}
+
 fn open_picker() -> ! {
     let json = herdr::herdr_json(["pane", "list"]).unwrap_or(serde_json::Value::Null);
     match picker_pane_decision(&json) {
         PickerDecision::Open => open_plugin_pane("picker", &["--focus"]),
+        PickerDecision::Focus(id) => run_plugin_pane_cmd("focus", &id),
+    }
+}
+
+// Launch-or-focus the popup picker within the focused workspace, mirroring the
+// overlay's `open` action but with a centered `popup` placement (80% x 80%)
+// instead of a full-screen overlay. Transient: closes on Enter/Esc like the
+// overlay, unlike the persistent side pane.
+fn open_popup_picker() -> ! {
+    let json = herdr::herdr_json(["pane", "list"]).unwrap_or(serde_json::Value::Null);
+    match popup_pane_decision(&json) {
+        PickerDecision::Open => open_plugin_pane(
+            "picker-popup",
+            &[
+                "--placement",
+                "popup",
+                "--width",
+                "80%",
+                "--height",
+                "80%",
+                "--focus",
+            ],
+        ),
         PickerDecision::Focus(id) => run_plugin_pane_cmd("focus", &id),
     }
 }
@@ -230,6 +262,39 @@ mod tests {
         ]);
         assert!(matches!(
             picker_pane_decision(&other_workspace),
+            PickerDecision::Open
+        ));
+    }
+
+    #[test]
+    fn popup_picker_opens_once_then_focuses_existing_in_focused_workspace() {
+        let no_popup = pane_list(vec![pane("w1:p1", "w1", None, true)]);
+        assert!(matches!(
+            popup_pane_decision(&no_popup),
+            PickerDecision::Open
+        ));
+
+        let existing_popup = pane_list(vec![
+            pane("w1:p1", "w1", None, true),
+            pane("w1:p2", "w1", Some(POPUP_PANE_LABEL), false),
+        ]);
+        assert!(
+            matches!(popup_pane_decision(&existing_popup), PickerDecision::Focus(id) if id == "w1:p2")
+        );
+
+        // A popup in another workspace does not count; open a fresh one here.
+        let other_workspace = pane_list(vec![
+            pane("w1:p1", "w1", None, true),
+            pane("w2:p2", "w2", Some(POPUP_PANE_LABEL), false),
+        ]);
+        assert!(matches!(
+            popup_pane_decision(&other_workspace),
+            PickerDecision::Open
+        ));
+
+        // A null/empty pane list degrades to Open.
+        assert!(matches!(
+            popup_pane_decision(&serde_json::Value::Null),
             PickerDecision::Open
         ));
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -244,6 +244,14 @@ fn execute_command(app: &mut App, command: Command, key: KeyEvent) -> Action {
             app.next();
             Action::Continue
         }
+        Command::PageUp => {
+            app.page_up();
+            Action::Continue
+        }
+        Command::PageDown => {
+            app.page_down();
+            Action::Continue
+        }
         Command::StartSearch => {
             app.query.clear();
             app.apply_filter();
@@ -308,7 +316,7 @@ fn execute_command(app: &mut App, command: Command, key: KeyEvent) -> Action {
     }
 }
 
-fn draw(f: &mut Frame, app: &App) -> ListHits {
+fn draw(f: &mut Frame, app: &mut App) -> ListHits {
     let area = f.area();
     f.render_widget(Clear, area);
     let mut outer = Block::default()
@@ -646,7 +654,7 @@ fn entry_branch(app: &App, entry: &Entry, group_end: bool) -> (&'static str, Col
     }
 }
 
-fn draw_list(f: &mut Frame, app: &App, area: Rect) -> ListHits {
+fn draw_list(f: &mut Frame, app: &mut App, area: Rect) -> ListHits {
     let show_scores = !app.query.trim().is_empty();
     let row_width = area.width.saturating_sub(3) as usize;
     let mut items = Vec::new();
@@ -819,6 +827,9 @@ fn draw_list(f: &mut Frame, app: &App, area: Rect) -> ListHits {
     state.select(selected_row);
     let block = Block::default().title(" Results ").borders(Borders::RIGHT);
     let list_area = block.inner(area);
+    // Record the visible row count so PageUp/PageDown can move by one page.
+    // Done after the block is built so the border is excluded.
+    app.list_height = list_area.height;
     let list = List::new(items)
         .block(block)
         .highlight_style(
@@ -1053,7 +1064,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, &app);
+                draw(f, &mut app);
             })
             .unwrap();
 
@@ -1096,7 +1107,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw_list(f, &app, f.area());
+                draw_list(f, &mut app, f.area());
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1190,7 +1201,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw_list(f, &app, f.area());
+                draw_list(f, &mut app, f.area());
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1222,7 +1233,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw_list(f, &app, f.area());
+                draw_list(f, &mut app, f.area());
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1357,7 +1368,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, &app);
+                draw(f, &mut app);
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1421,7 +1432,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, &app);
+                draw(f, &mut app);
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1437,7 +1448,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, &app);
+                draw(f, &mut app);
             })
             .unwrap();
         let text = buffer_text(&terminal);
@@ -1462,7 +1473,7 @@ mod tests {
         let backend = TestBackend::new(50, 12);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut hits = ListHits::default();
-        terminal.draw(|f| hits = draw(f, &app)).unwrap();
+        terminal.draw(|f| hits = draw(f, &mut app)).unwrap();
         let visible_row = buffer_text(&terminal)
             .lines()
             .position(|line| line.contains("one"))
@@ -1500,7 +1511,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut hits = ListHits::default();
         terminal
-            .draw(|f| hits = draw_list(f, &app, f.area()))
+            .draw(|f| hits = draw_list(f, &mut app, f.area()))
             .unwrap();
         let lines: Vec<_> = buffer_text(&terminal).lines().map(str::to_owned).collect();
         let detail_row = lines


### PR DESCRIPTION
## Summary

Adds `PageUp` / `PageDown` to move the selection by one visible page, in addition to the existing `Up` / `Down` single-step movement.

## What changed

- New `Command::PageUp` / `Command::PageDown` in `src/keymap.rs`, bound to `PageUp` / `PageDown` keys, in the `Navigation` group.
- `App` records the rendered list area height (`app.list_height`, set in `draw_list`) and exposes `page_up` / `page_down` that move `selected` by that many entries, clamping at `0` and `len - 1`.
- `execute_command` dispatches the two new commands.
- `draw` and `draw_list` now take `&mut App` so the list height can be recorded during render; all call sites updated.

## Why record the height during draw

The page size must match the *visible* list area, which differs across placements: the overlay is full-screen, the popup is 80% × 80%, and the side pane is a split. `f.area()` (and thus the list area) reflects the actual pane size for each placement, so paging stays accurate in all three. Computing from `crossterm::terminal::size()` would be wrong for the popup/side placements. Before the first frame renders, `list_height` is `0` and the page size falls back to `1` (a single step) — no panic.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo build --release`
- [x] New unit tests:
  - `page_down_advances_by_list_height_and_clamps_at_end` — pages by 10 with `list_height=10`, clamps at last index; verifies the `list_height=0` fallback to step-by-1.
  - `page_up_moves_back_by_list_height_and_clamps_at_zero` — pages back by 10, clamps at 0.
  - `page_movement_is_noop_on_empty_results` — no panic / no movement on empty list.
- [x] No regressions: the 3 pre-existing failures on `main` are unchanged (100 passed now vs 97 before, +3 new tests).

## CHANGELOG

Updated under `Unreleased`.
